### PR TITLE
Fixes to get tests passing in Python 3.

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -1,5 +1,6 @@
 from bs4 import BeautifulSoup, NavigableString
 import re
+import six
 
 
 convert_heading_re = re.compile(r'convert_h(\d+)')
@@ -61,7 +62,7 @@ class MarkdownConverter(object):
         # Convert the children first
         for el in node.children:
             if isinstance(el, NavigableString):
-                text += self.process_text(unicode(el))
+                text += self.process_text(six.text_type(el))
             else:
                 text += self.process_tag(el)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ read = lambda filepath: codecs.open(filepath, 'r', 'utf-8').read()
 
 
 pkgmeta = {}
-execfile(os.path.join(os.path.dirname(__file__), 'markdownify', 'pkgmeta.py'),
+exec(open(os.path.join(os.path.dirname(__file__), 'markdownify', 'pkgmeta.py')).read(),
          pkgmeta)
 
 
@@ -75,7 +75,7 @@ setup(
         'pytest',
     ],
     install_requires=[
-        'beautifulsoup4',
+        'beautifulsoup4', 'six'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
There were only a couple necessary changes to get Python 3 support.
1. Python 3 removed the global `execfile` function.
   https://docs.python.org/3.5/whatsnew/3.0.html?highlight=execfile#builtins
2. I've included `six` and replaced an instance of `unicode` with `six.text_type`.
   https://pythonhosted.org/six/#six.text_type

I've tested with Python 2.7 and 3.4.
