### PR TITLE
version 1.0.0 update to handle new markdown format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ read = lambda filepath: codecs.open(filepath, 'r', 'utf-8').read()
 pkgmeta = {
     '__title__': 'markdownify',
     '__author__': 'Matthew Tretter',
-    '__version__': '0.4.1',
+    '__version__': '1.0.0',
 }
 
 


### PR DESCRIPTION
Hey Matthew,

After utilizing your plugin, I noticed some antiquated markdown syntax that was causing conversion issues with sending text to JIRA for Markdown rendering.  

I updated the plugin to include properly handle
```
<i></i> to _%s_
<u></u> to +%s+
<del></del> to -%s-
<sup></sup> to ^%s^
<sub></sub> to ~%s~
<sub></sub> to ??%s??

Headings converted from using # to new markdown format
'h{}. '.format(n)        //n element detected by beautifulSoup 

Also removed extra /n from heading conversion
```

I also updated setup.py, by incrementing dependency version by a major version change to 1.0.0; to indicate no backwards compatibility.  