### PR TITLE
Add newline before and after a markdown list

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -153,7 +153,7 @@ class MarkdownConverter(object):
             el = el.parent
         if nested:
             text = '\n' + self.indent(text, 1)
-        return text
+        return '\n' + text + '\n'
 
     convert_ul = convert_list
     convert_ol = convert_list

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -103,6 +103,9 @@ def test_strong():
 
 def test_ul():
     assert md('<ul><li>a</li><li>b</li></ul>') == '* a\n* b\n'
+    
+def test_inline_ul():
+    assert md('<p>foo</p><ul><li>a</li><li>b</li></ul><p>bar</p>') == 'foo \n* a\n* b\n\nbar'
 
 
 def test_nested_uls():


### PR DESCRIPTION
Fixes matthewwithanm#5 as well as an issue where `<p>foo<p><ul><li>bar</li></ul>` gets converted to `foo * bar` which is not correct