### PR TITLE
Lists handling correction

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -151,14 +151,19 @@ class MarkdownConverter(object):
 
     def convert_list(self, el, text):
         nested = False
+        before_paragraph = False
+        print(el.name, repr(el.next_sibling), repr(text))
+        if el.next_sibling and el.next_sibling.name not in ['ul', 'ol']:
+            print(el.name, repr(el.next_sibling))
+            before_paragraph = True
         while el:
             if el.name == 'li':
                 nested = True
                 break
             el = el.parent
         if nested:
-            text = '\n' + self.indent(text, 1)
-        return '\n' + text + '\n'
+            text = '\n' + self.indent(text, 1).rstrip()
+        return text + ('\n' if before_paragraph else '')
 
     convert_ul = convert_list
     convert_ol = convert_list

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -152,9 +152,7 @@ class MarkdownConverter(object):
     def convert_list(self, el, text):
         nested = False
         before_paragraph = False
-        print(el.name, repr(el.next_sibling), repr(text))
         if el.next_sibling and el.next_sibling.name not in ['ul', 'ol']:
-            print(el.name, repr(el.next_sibling))
             before_paragraph = True
         while el:
             if el.name == 'li':

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -59,6 +59,11 @@ class MarkdownConverter(object):
     def process_tag(self, node, children_only=False):
         text = ''
 
+        # Clean newline-only textnodes outside <pre>
+        for el in node.children:
+            if node.name != 'pre' and isinstance(el, NavigableString) and six.text_type(el) == '\n':
+                el.extract()
+
         # Convert the children first
         for el in node.children:
             if isinstance(el, NavigableString):

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -126,8 +126,7 @@ def test_ul():
     assert md('<ul><li>a</li><li>b</li></ul>') == '* a\n* b\n'
     
 def test_inline_ul():
-    assert md('<p>foo</p><ul><li>a</li><li>b</li></ul><p>bar</p>') == 'foo \n* a\n* b\n\nbar'
-
+    assert md('<p>foo</p><ul><li>a</li><li>b</li></ul><p>bar</p>') == 'foo\n\n* a\n* b\n\nbar\n\n'
 
 def test_nested_uls():
     """

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -2,7 +2,7 @@ from markdownify import markdownify as md, ATX, ATX_CLOSED
 import re
 
 
-nested_uls = re.sub('\s+', '', """
+nested_uls = """
     <ul>
         <li>1
             <ul>
@@ -19,7 +19,26 @@ nested_uls = re.sub('\s+', '', """
         </li>
         <li>2</li>
         <li>3</li>
-    </ul>""")
+    </ul>"""
+
+nested_ols = """
+    <ol>
+        <li>1
+            <ol>
+                <li>a
+                    <ol>
+                        <li>I</li>
+                        <li>II</li>
+                        <li>III</li>
+                    </ol>
+                </li>
+                <li>b</li>
+                <li>c</li>
+            </ol>
+        </li>
+        <li>2</li>
+        <li>3</li>
+    </ul>"""
 
 
 def test_a():
@@ -92,6 +111,8 @@ def test_i():
 def test_ol():
     assert md('<ol><li>a</li><li>b</li></ol>') == '1. a\n2. b\n'
 
+def test_nested_ols():
+    assert md(nested_ols) == '1. 1 \n\t1. a \n\t\t1. I\n\t\t2. II\n\t\t3. III\n\t2. b\n\t3. c\n2. 2\n3. 3\n'
 
 def test_p():
     assert md('<p>hello</p>') == 'hello\n\n'
@@ -113,11 +134,11 @@ def test_nested_uls():
     Nested ULs should alternate bullet characters.
 
     """
-    assert md(nested_uls) == '* 1\n\t+ a\n\t\t- I\n\t\t- II\n\t\t- III\n\t\t\n\t+ b\n\t+ c\n\t\n* 2\n* 3\n'
+    assert md(nested_uls) == '* 1 \n\t+ a \n\t\t- I\n\t\t- II\n\t\t- III\n\t+ b\n\t+ c\n* 2\n* 3\n'
 
 
 def test_bullets():
-    assert md(nested_uls, bullets='-') == '- 1\n\t- a\n\t\t- I\n\t\t- II\n\t\t- III\n\t\t\n\t- b\n\t- c\n\t\n- 2\n- 3\n'
+    assert md(nested_uls, bullets='-') == '- 1 \n\t- a \n\t\t- I\n\t\t- II\n\t\t- III\n\t- b\n\t- c\n- 2\n- 3\n'
 
 
 def test_img():


### PR DESCRIPTION
Solves #8, add tests and correct spaces and newlines after `<ol>` and `<ul>` to improve nesting:

Previously,
```
    <ul>
        <li>1
            <ul>
                <li>a
                    <ul>
                        <li>I</li>
                        <li>II</li>
                        <li>III</li>
                    </ul>
                </li>
                <li>b</li>
                <li>c</li>
            </ul>
        </li>
        <li>2</li>
        <li>3</li>
    </ul>
```

was rendered `\n* 1\n\n\t+ a\n\t\n\t\t- I\n\t\t- II\n\t\t- III\n\t\t\n\t\n\t+ b\n\t+ c\n\t\n\n* 2\n* 3\n\n` i.e.
> * 1
> 
> 	+ a
> 	
> 		- I
> 		- II
> 		- III
> 		
> 	
> 	+ b
> 	+ c
> 	
> 
> * 2
> * 3
> 
> 

and now `* 1 \n\t+ a \n\t\t- I\n\t\t- II\n\t\t- III\n\t+ b\n\t+ c\n* 2\n* 3\n` i.e.
> * 1 
> 	+ a 
> 		- I
> 		- II
> 		- III
> 	+ b
> 	+ c
> * 2
> * 3
>

Note: spaces appeared at the end of textnodes followed by nested lists and should be trimed