### PR TITLE
Add methods for code, samp, kbd tags

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -143,6 +143,18 @@ class MarkdownConverter(object):
             return ''
         return '%s*%s*%s' % (prefix, text, suffix)
 
+    def convert_code(self, el, text):
+        prefix, suffix, text = chomp(text)
+        if not text:
+            return ''
+        return '%s`%s`%s' % (prefix, text, suffix)
+
+    def convert_samp(self, el, text):
+        return self.convert_code(el, text)
+
+    def convert_kbd(self, el, text):
+        return self.convert_code(el, text)
+
     def convert_hn(self, n, el, text):
         style = self.options['heading_style']
         text = text.rstrip()

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -10,4 +10,4 @@ def test_code_with_tricky_content():
     assert md('<code>></code>') == "`>`"
     assert md('<code>/home/</code><b>username</b>') == "`/home/`**username**"
     assert md('First line <code>blah blah<br />blah blah</code> second line') \
-            == "First line `blah blah  \nblah blah` second line"
+        == "First line `blah blah  \nblah blah` second line"

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -9,6 +9,5 @@ def test_nested():
 def test_code_with_tricky_content():
     assert md('<code>></code>') == "`>`"
     assert md('<code>/home/</code><b>username</b>') == "`/home/`**username**"
-    # convert_br() adds trailing spaces (why?); ignore them by using 2 tests,
-    assert md('<code>Line1<br />Line2</code>').startswith("`Line1")
-    assert md('<code>Line1<br />Line2</code>').endswith("\nLine2`")
+    assert md('First line <code>blah blah<br />blah blah</code> second line') \
+            == "First line `blah blah  \nblah blah` second line"

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -4,3 +4,11 @@ from markdownify import markdownify as md
 def test_nested():
     text = md('<p>This is an <a href="http://example.com/">example link</a>.</p>')
     assert text == 'This is an [example link](http://example.com/).\n\n'
+
+
+def test_code_with_tricky_content():
+    assert md('<code>></code>') == "`>`"
+    assert md('<code>/home/</code><b>username</b>') == "`/home/`**username**"
+    # convert_br() adds trailing spaces (why?); ignore them by using 2 tests,
+    assert md('<code>Line1<br />Line2</code>').startswith("`Line1")
+    assert md('<code>Line1<br />Line2</code>').endswith("\nLine2`")

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -94,6 +94,27 @@ def test_em_spaces():
     assert md('foo <em></em> bar') == 'foo  bar'
 
 
+def code_samp_kbd_tests(tag):
+    # Basically re-use test_em() and test_em_spaces(),
+    assert md(f'<{tag}>Hello</{tag}>') == '`Hello`'
+    assert md(f'foo <{tag}>Hello</{tag}> bar') == 'foo `Hello` bar'
+    assert md(f'foo<{tag}> Hello</{tag}> bar') == 'foo `Hello` bar'
+    assert md(f'foo <{tag}>Hello </{tag}>bar') == 'foo `Hello` bar'
+    assert md(f'foo <{tag}></{tag}> bar') in ['foo  bar', 'foo bar']  # Either is OK
+
+
+def test_code():
+    code_samp_kbd_tests('code')
+
+
+def test_samp():
+    code_samp_kbd_tests('samp')
+
+
+def test_kbd():
+    code_samp_kbd_tests('kbd')
+
+
 def test_h1():
     assert md('<h1>Hello</h1>') == 'Hello\n=====\n\n'
 


### PR DESCRIPTION
Add methods and tests for inline tags `<code>` (also `<samp>` and `<kbd>` using the same base method).