### PR TITLE
Add ignore comment tags

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -1,4 +1,4 @@
-from bs4 import BeautifulSoup, NavigableString
+from bs4 import BeautifulSoup, NavigableString, Comment
 import re
 import six
 
@@ -75,7 +75,9 @@ class MarkdownConverter(object):
 
         # Convert the children first
         for el in node.children:
-            if isinstance(el, NavigableString):
+            if isinstance(el, Comment):
+                continue
+            elif isinstance(el, NavigableString):
                 text += self.process_text(six.text_type(el))
             else:
                 text += self.process_tag(el, convert_children_as_inline)

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -5,9 +5,11 @@ def test_nested():
     text = md('<p>This is an <a href="http://example.com/">example link</a>.</p>')
     assert text == 'This is an [example link](http://example.com/).\n\n'
 
+
 def test_ignore_comments():
     text = md("<!-- This is a comment -->")
     assert text == ""
+
 
 def test_ignore_comments_with_other_tags():
     text = md("<!-- This is a comment --><a href='http://example.com/'>example link</a>")

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -4,3 +4,11 @@ from markdownify import markdownify as md
 def test_nested():
     text = md('<p>This is an <a href="http://example.com/">example link</a>.</p>')
     assert text == 'This is an [example link](http://example.com/).\n\n'
+
+def test_ignore_comments():
+    text = md("<!-- This is a comment -->")
+    assert text == ""
+
+def test_ignore_comments_with_other_tags():
+    text = md("<!-- This is a comment --><a href='http://example.com/'>example link</a>")
+    assert text == "[example link](http://example.com/)"


### PR DESCRIPTION
Fixes #33 

### Changed
When we're parsing an element we should check if the element is a `Comment` instance, if it is, then we should ignore it.

### Note
LMK if it is a valid PR and/or I should make changes, like ignoring comments only if an option is provided.