### PR TITLE
Add basic support for tables

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -245,12 +245,11 @@ class MarkdownConverter(object):
             columns = row.find_all('td')
             if len(headers) > 0:
                 headers = [head.text.strip() for head in headers]
-                headers = [head for head in headers if head]
                 text_data.append(' | '.join(headers))
                 text_data.append(' | '.join(['---'] * len(headers)))
             elif len(columns) > 0:
                 columns = [colm.text.strip() for colm in columns]
-                text_data.append(' | '.join([colm for colm in columns if colm]))
+                text_data.append(' | '.join(columns))
             else:
                 continue
         return '\n'.join(text_data)

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -237,6 +237,24 @@ class MarkdownConverter(object):
 
         return '![%s](%s%s)' % (alt, src, title_part)
 
+    def convert_table(self, el, text, convert_as_inline):
+        rows = el.find_all('tr')
+        text_data = []
+        for row in rows:
+            headers = row.find_all('th')
+            columns = row.find_all('td')
+            if len(headers) > 0:
+                headers = [head.text.strip() for head in headers]
+                headers = [head for head in headers if head]
+                text_data.append(' | '.join(headers))
+                text_data.append(' | '.join(['---'] * len(headers)))
+            elif len(columns) > 0:
+                columns = [colm.text.strip() for colm in columns]
+                text_data.append(' | '.join([colm for colm in columns if colm]))
+            else:
+                continue
+        return '\n'.join(text_data)
+
 
 def markdownify(html, **options):
     return MarkdownConverter(**options).convert(html)

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -245,12 +245,11 @@ class MarkdownConverter(object):
             columns = row.find_all('td')
             if len(headers) > 0:
                 headers = [head.text.strip() for head in headers]
-                headers = [head for head in headers if head]
-                text_data.append(' | '.join(headers))
-                text_data.append(' | '.join(['---'] * len(headers)))
+                text_data.append('| ' + ' | '.join(headers) + ' |')
+                text_data.append('| ' + ' | '.join(['---'] * len(headers)) + ' |')
             elif len(columns) > 0:
                 columns = [colm.text.strip() for colm in columns]
-                text_data.append(' | '.join(columns))
+                text_data.append('| ' + ' | '.join(columns) + ' |')
             else:
                 continue
         return '\n'.join(text_data)

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -245,6 +245,7 @@ class MarkdownConverter(object):
             columns = row.find_all('td')
             if len(headers) > 0:
                 headers = [head.text.strip() for head in headers]
+                headers = [head for head in headers if head]
                 text_data.append(' | '.join(headers))
                 text_data.append(' | '.join(['---'] * len(headers)))
             elif len(columns) > 0:

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -67,11 +67,11 @@ table_head_body = re.sub(r'\s+', '', """
 </table>
 """)
 
-table_missing_header = re.sub(r'\s+', '', """
+table_missing_text = re.sub(r'\s+', '', """
 <table>
     <thead>
             <tr>
-            <th></th>
+            <th>Firstname</th>
             <th>Lastname</th>
             <th>Age</th>
             </tr>
@@ -79,7 +79,7 @@ table_missing_header = re.sub(r'\s+', '', """
     <tbody>
         <tr>
             <td>Jill</td>
-            <td>Smith</td>
+            <td></td>
             <td>50</td>
         </tr>
         <tr>
@@ -291,4 +291,4 @@ def test_div():
 def test_table():
     assert md(table) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'
     assert md(table_head_body) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'
-    assert md(table_missing_header) == ' | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'
+    assert md(table_missing_text) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill |  | 50\nEve | Jackson | 94'

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -77,11 +77,6 @@ def test_chomp():
     assert md(' <b> s</b> ') == '  **s** '
     assert md(' <b> s </b> ') == '  **s**  '
     assert md(' <b>  s  </b> ') == '  **s**  '
-    assert md('<b>bold with br<br></b><i>italic</i>') == '**bold with br***italic*'
-
-
-def test_chomp_ext():
-    assert md('<b>bold with br<br></b><i>italic</i>') == '**bold with br***italic*'
 
 
 def test_a():

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -22,6 +22,52 @@ nested_uls = re.sub(r'\s+', '', """
     </ul>""")
 
 
+table = re.sub(r'\s+', '', """
+<table>
+    <tr>
+        <th>Firstname</th>
+        <th>Lastname</th> 
+        <th>Age</th>
+    </tr>
+    <tr>
+        <td>Jill</td>
+        <td>Smith</td> 
+        <td>50</td>
+    </tr>
+    <tr>
+        <td>Eve</td>
+        <td>Jackson</td> 
+        <td>94</td>
+    </tr>
+</table>
+""")
+
+
+table_head_body = re.sub(r'\s+', '', """
+<table>
+    <thead>
+            <tr>
+            <th>Firstname</th>
+            <th>Lastname</th>
+            <th>Age</th>
+            </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Jill</td>
+            <td>Smith</td> 
+            <td>50</td>
+        </tr>
+        <tr>
+            <td>Eve</td>
+            <td>Jackson</td> 
+            <td>94</td>
+        </tr>
+    </tbody>
+</table>
+""")
+
+
 def test_chomp():
     assert md(' <b></b> ') == '  '
     assert md(' <b> </b> ') == '  '
@@ -31,6 +77,11 @@ def test_chomp():
     assert md(' <b> s</b> ') == '  **s** '
     assert md(' <b> s </b> ') == '  **s**  '
     assert md(' <b>  s  </b> ') == '  **s**  '
+    assert md('<b>bold with br<br></b><i>italic</i>') == '**bold with br***italic*'
+
+
+def test_chomp_ext():
+    assert md('<b>bold with br<br></b><i>italic</i>') == '**bold with br***italic*'
 
 
 def test_a():
@@ -216,3 +267,8 @@ def test_img():
 
 def test_div():
     assert md('Hello</div> World') == 'Hello World'
+
+
+def test_table():
+    assert md(table) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'
+    assert md(table_head_body) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -26,17 +26,17 @@ table = re.sub(r'\s+', '', """
 <table>
     <tr>
         <th>Firstname</th>
-        <th>Lastname</th> 
+        <th>Lastname</th>
         <th>Age</th>
     </tr>
     <tr>
         <td>Jill</td>
-        <td>Smith</td> 
+        <td>Smith</td>
         <td>50</td>
     </tr>
     <tr>
         <td>Eve</td>
-        <td>Jackson</td> 
+        <td>Jackson</td>
         <td>94</td>
     </tr>
 </table>
@@ -55,12 +55,12 @@ table_head_body = re.sub(r'\s+', '', """
     <tbody>
         <tr>
             <td>Jill</td>
-            <td>Smith</td> 
+            <td>Smith</td>
             <td>50</td>
         </tr>
         <tr>
             <td>Eve</td>
-            <td>Jackson</td> 
+            <td>Jackson</td>
             <td>94</td>
         </tr>
     </tbody>

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -67,6 +67,30 @@ table_head_body = re.sub(r'\s+', '', """
 </table>
 """)
 
+table_missing_header = re.sub(r'\s+', '', """
+<table>
+    <thead>
+            <tr>
+            <th></th>
+            <th>Lastname</th>
+            <th>Age</th>
+            </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Jill</td>
+            <td>Smith</td>
+            <td>50</td>
+        </tr>
+        <tr>
+            <td>Eve</td>
+            <td>Jackson</td>
+            <td>94</td>
+        </tr>
+    </tbody>
+</table>
+""")
+
 
 def test_chomp():
     assert md(' <b></b> ') == '  '
@@ -267,3 +291,4 @@ def test_div():
 def test_table():
     assert md(table) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'
     assert md(table_head_body) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'
+    assert md(table_missing_header) == ' | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -71,7 +71,7 @@ table_missing_text = re.sub(r'\s+', '', """
 <table>
     <thead>
             <tr>
-            <th>Firstname</th>
+            <th></th>
             <th>Lastname</th>
             <th>Age</th>
             </tr>
@@ -289,6 +289,6 @@ def test_div():
 
 
 def test_table():
-    assert md(table) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'
-    assert md(table_head_body) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill | Smith | 50\nEve | Jackson | 94'
-    assert md(table_missing_text) == 'Firstname | Lastname | Age\n--- | --- | ---\nJill |  | 50\nEve | Jackson | 94'
+    assert md(table) == '| Firstname | Lastname | Age |\n| --- | --- | --- |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |'
+    assert md(table_head_body) == '| Firstname | Lastname | Age |\n| --- | --- | --- |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |'
+    assert md(table_missing_text) == '|  | Lastname | Age |\n| --- | --- | --- |\n| Jill |  | 50 |\n| Eve | Jackson | 94 |'


### PR DESCRIPTION
Fixed #32 

Adding basic support to tables:

 - Parse table header
 - Parse table rows
 - Parse table when using a `thead` and `tbody`
 - Add support for bold, italic and etc in table rows (Perhaps in a future implementation)
 - Add alignment support (Perhaps in a future implementation)