### PR TITLE
Add `strong_em_symbol` and `newline` options to the converter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ strong_em_symbol
   In markdown, both ``*`` and ``_`` are used to encode **strong** or *emphasized* texts. The preferred symbol can be passed through this argument, that defaults to ``*``.
 
 newline_style
-  Defines the style of marking linebreaks (``<br>``) in markdown. The default value ``SPACES`` of this option means the regular ``  \n`` will be used (i.e. two spaces and a newline), while ``BACKSLASH`` will convert a linebreak to ``\\n`` (a backslash an a newline). While the latter convention is non-standard, it is commonly preferred and supported by a lot of interpreters.
+  Defines the style of marking linebreaks (``<br>``) in markdown. The default value ``SPACES`` of this option will adopt the usual two spaces and a newline, while ``BACKSLASH`` will convert a linebreak to ``\\n`` (a backslash an a newline). While the latter convention is non-standard, it is commonly preferred and supported by a lot of interpreters.
 
 Options may be specified as kwargs to the ``markdownify`` function, or as a
 nested ``Options`` class in ``MarkdownConverter`` subclasses.

--- a/README.rst
+++ b/README.rst
@@ -76,10 +76,10 @@ bullets
   level. Defaults to ``'*+-'``.
 
 strong_em_symbol
-  In markdown, both `*` and `_` are used to encode **strong** or *emphasized* texts. The preferred symbol can be passed through this argument, which defaults to `*`.
+  In markdown, both ``*`` and ``_`` are used to encode **strong** or *emphasized* texts. The preferred symbol can be passed through this argument, that defaults to ``*``.
 
 newline
-  Defines the style of marking linebreaks (`<br>`) in markdown. The default value `'spaces'` of this option means the regular '  \n' will be used (i.e. two spaces and a newline), while `'backslash'` will convert a linebreak to `''\\\n'` (a backslash an a newline). While the latter convention is non-standard, it is commonly preferred and supported by a lot of converters.
+  Defines the style of marking linebreaks (``<br>``) in markdown. The default value ``'spaces'`` of this option means the regular ``  \n`` will be used (i.e. two spaces and a newline), while ``'backslash'`` will convert a linebreak to ``\\n`` (a backslash an a newline). While the latter convention is non-standard, it is commonly preferred and supported by a lot of interpreters.
 
 Options may be specified as kwargs to the ``markdownify`` function, or as a
 nested ``Options`` class in ``MarkdownConverter`` subclasses.

--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,8 @@ bullets
 strong_em_symbol
   In markdown, both ``*`` and ``_`` are used to encode **strong** or *emphasized* texts. The preferred symbol can be passed through this argument, that defaults to ``*``.
 
-newline
-  Defines the style of marking linebreaks (``<br>``) in markdown. The default value ``'spaces'`` of this option means the regular ``  \n`` will be used (i.e. two spaces and a newline), while ``'backslash'`` will convert a linebreak to ``\\n`` (a backslash an a newline). While the latter convention is non-standard, it is commonly preferred and supported by a lot of interpreters.
+newline_style
+  Defines the style of marking linebreaks (``<br>``) in markdown. The default value ``SPACES`` of this option means the regular ``  \n`` will be used (i.e. two spaces and a newline), while ``BACKSLASH`` will convert a linebreak to ``\\n`` (a backslash an a newline). While the latter convention is non-standard, it is commonly preferred and supported by a lot of interpreters.
 
 Options may be specified as kwargs to the ``markdownify`` function, or as a
 nested ``Options`` class in ``MarkdownConverter`` subclasses.

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,12 @@ bullets
   lists are nested. Otherwise, the bullet will alternate based on nesting
   level. Defaults to ``'*+-'``.
 
+strong_em_symbol
+  In markdown, both `*` and `_` are used to encode **strong** or *emphasized* texts. The preferred symbol can be passed through this argument, which defaults to `*`.
+
+newline
+  Defines the style of marking linebreaks (`<br>`) in markdown. The default value `'spaces'` of this option means the regular '  \n' will be used (i.e. two spaces and a newline), while `'backslash'` will convert a linebreak to `''\\\n'` (a backslash an a newline). While the latter convention is non-standard, it is commonly preferred and supported by a lot of converters.
+
 Options may be specified as kwargs to the ``markdownify`` function, or as a
 nested ``Options`` class in ``MarkdownConverter`` subclasses.
 

--- a/README.rst
+++ b/README.rst
@@ -76,10 +76,16 @@ bullets
   level. Defaults to ``'*+-'``.
 
 strong_em_symbol
-  In markdown, both ``*`` and ``_`` are used to encode **strong** or *emphasized* texts. The preferred symbol can be passed through this argument, that defaults to ``*``.
+  In markdown, both ``*`` and ``_`` are used to encode **strong** or
+  *emphasized* texts. Either of these symbols can be chosen by the options
+  ``ASTERISK`` (default) or ``UNDERSCORE`` respectively.
 
 newline_style
-  Defines the style of marking linebreaks (``<br>``) in markdown. The default value ``SPACES`` of this option will adopt the usual two spaces and a newline, while ``BACKSLASH`` will convert a linebreak to ``\\n`` (a backslash an a newline). While the latter convention is non-standard, it is commonly preferred and supported by a lot of interpreters.
+  Defines the style of marking linebreaks (``<br>``) in markdown. The default
+  value ``SPACES`` of this option will adopt the usual two spaces and a newline,
+  while ``BACKSLASH`` will convert a linebreak to ``\\n`` (a backslash an a
+  newline). While the latter convention is non-standard, it is commonly
+  preferred and supported by a lot of interpreters.
 
 Options may be specified as kwargs to the ``markdownify`` function, or as a
 nested ``Options`` class in ``MarkdownConverter`` subclasses.

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -46,6 +46,7 @@ class MarkdownConverter(object):
         autolinks = True
         heading_style = UNDERLINED
         bullets = '*+-'  # An iterable of bullet types.
+        strong_em_symbol = '*'
 
     class Options(DefaultOptions):
         pass
@@ -157,10 +158,11 @@ class MarkdownConverter(object):
         return '  \n'
 
     def convert_em(self, el, text, convert_as_inline):
+        em_tag = self.options['strong_em_symbol']
         prefix, suffix, text = chomp(text)
         if not text:
             return ''
-        return '%s*%s*%s' % (prefix, text, suffix)
+        return '%s%s%s%s%s' % (prefix, em_tag, text, em_tag, suffix)
 
     def convert_hn(self, n, el, text, convert_as_inline):
         if convert_as_inline:
@@ -222,10 +224,11 @@ class MarkdownConverter(object):
         return '%s\n\n' % text if text else ''
 
     def convert_strong(self, el, text, convert_as_inline):
+        strong_tag = 2 * self.options['strong_em_symbol']
         prefix, suffix, text = chomp(text)
         if not text:
             return ''
-        return '%s**%s**%s' % (prefix, text, suffix)
+        return '%s%s%s%s%s' % (prefix, strong_tag, text, strong_tag, suffix)
 
     def convert_img(self, el, text, convert_as_inline):
         alt = el.attrs.get('alt', None) or ''

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -159,7 +159,7 @@ class MarkdownConverter(object):
         if convert_as_inline:
             return ""
 
-        if self.options['newline_style'] == BACKSLASH:
+        if self.options['newline_style'].lower() == BACKSLASH:
             return '\\\n'
         else:
             return '  \n'
@@ -175,7 +175,7 @@ class MarkdownConverter(object):
         if convert_as_inline:
             return text
 
-        style = self.options['heading_style']
+        style = self.options['heading_style'].lower()
         text = text.rstrip()
         if style == UNDERLINED and n <= 2:
             line = '=' if n == 1 else '-'

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -19,6 +19,7 @@ SETEXT = UNDERLINED
 SPACES = 'spaces'
 BACKSLASH = 'backslash'
 
+
 def escape(text):
     if not text:
         return ''

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -15,6 +15,9 @@ ATX_CLOSED = 'atx_closed'
 UNDERLINED = 'underlined'
 SETEXT = UNDERLINED
 
+# Newline style
+SPACES = 'spaces'
+BACKSLASH = 'backslash'
 
 def escape(text):
     if not text:
@@ -47,7 +50,7 @@ class MarkdownConverter(object):
         heading_style = UNDERLINED
         bullets = '*+-'  # An iterable of bullet types.
         strong_em_symbol = '*'
-        newline = 'spaces'
+        newline_style = SPACES
 
     class Options(DefaultOptions):
         pass
@@ -156,7 +159,7 @@ class MarkdownConverter(object):
         if convert_as_inline:
             return ""
 
-        if self.options['newline'] == 'backslash':
+        if self.options['newline_style'] == BACKSLASH:
             return '\\\n'
         else:
             return '  \n'

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -19,6 +19,10 @@ SETEXT = UNDERLINED
 SPACES = 'spaces'
 BACKSLASH = 'backslash'
 
+# Strong and emphasis style
+ASTERISK = '*'
+UNDERSCORE = '_'
+
 
 def escape(text):
     if not text:
@@ -50,7 +54,7 @@ class MarkdownConverter(object):
         autolinks = True
         heading_style = UNDERLINED
         bullets = '*+-'  # An iterable of bullet types.
-        strong_em_symbol = '*'
+        strong_em_symbol = ASTERISK
         newline_style = SPACES
 
     class Options(DefaultOptions):

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -47,6 +47,7 @@ class MarkdownConverter(object):
         heading_style = UNDERLINED
         bullets = '*+-'  # An iterable of bullet types.
         strong_em_symbol = '*'
+        newline = 'spaces'
 
     class Options(DefaultOptions):
         pass
@@ -155,7 +156,10 @@ class MarkdownConverter(object):
         if convert_as_inline:
             return ""
 
-        return '  \n'
+        if self.options['newline'] == 'backslash':
+            return '\\\n'
+        else:
+            return '  \n'
 
     def convert_em(self, el, text, convert_as_inline):
         em_tag = self.options['strong_em_symbol']

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,4 +1,4 @@
-from markdownify import markdownify as md, ATX, ATX_CLOSED, BACKSLASH
+from markdownify import markdownify as md, ATX, ATX_CLOSED, BACKSLASH, UNDERSCORE
 import re
 
 
@@ -219,10 +219,10 @@ def test_div():
 
 
 def test_strong_em_symbol():
-    assert md('<strong>Hello</strong>', strong_em_symbol='_') == '__Hello__'
-    assert md('<b>Hello</b>', strong_em_symbol='_') == '__Hello__'
-    assert md('<em>Hello</em>', strong_em_symbol='_') == '_Hello_'
-    assert md('<i>Hello</i>', strong_em_symbol='_') == '_Hello_'
+    assert md('<strong>Hello</strong>', strong_em_symbol=UNDERSCORE) == '__Hello__'
+    assert md('<b>Hello</b>', strong_em_symbol=UNDERSCORE) == '__Hello__'
+    assert md('<em>Hello</em>', strong_em_symbol=UNDERSCORE) == '_Hello_'
+    assert md('<i>Hello</i>', strong_em_symbol=UNDERSCORE) == '_Hello_'
 
 
 def test_newline_style():

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,4 +1,4 @@
-from markdownify import markdownify as md, ATX, ATX_CLOSED
+from markdownify import markdownify as md, ATX, ATX_CLOSED, BACKSLASH
 import re
 
 
@@ -86,6 +86,7 @@ def test_nested_blockquote():
 
 def test_br():
     assert md('a<br />b<br />c') == 'a  \nb  \nc'
+    assert md('a<br />b<br />c', newline_style=BACKSLASH) == 'a\\\nb\\\nc'
 
 
 def test_em():

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -65,7 +65,6 @@ def test_a_no_autolinks():
 
 def test_b():
     assert md('<b>Hello</b>') == '**Hello**'
-    assert md('<b>Hello</b>', strong_em_symbol='_') == '__Hello__'
 
 
 def test_b_spaces():
@@ -86,12 +85,10 @@ def test_nested_blockquote():
 
 def test_br():
     assert md('a<br />b<br />c') == 'a  \nb  \nc'
-    assert md('a<br />b<br />c', newline_style=BACKSLASH) == 'a\\\nb\\\nc'
 
 
 def test_em():
     assert md('<em>Hello</em>') == '*Hello*'
-    assert md('<em>Hello</em>', strong_em_symbol='_') == '_Hello_'
 
 
 def test_em_spaces():
@@ -177,7 +174,6 @@ def test_atx_closed_headings():
 
 def test_i():
     assert md('<i>Hello</i>') == '*Hello*'
-    assert md('<i>Hello</i>', strong_em_symbol='_') == '_Hello_'
 
 
 def test_ol():
@@ -191,7 +187,6 @@ def test_p():
 
 def test_strong():
     assert md('<strong>Hello</strong>') == '**Hello**'
-    assert md('<strong>Hello</strong>', strong_em_symbol='_') == '__Hello__'
 
 
 def test_ul():
@@ -221,3 +216,14 @@ def test_img():
 
 def test_div():
     assert md('Hello</div> World') == 'Hello World'
+
+
+def test_strong_em_symbol():
+    assert md('<strong>Hello</strong>', strong_em_symbol='_') == '__Hello__'
+    assert md('<b>Hello</b>', strong_em_symbol='_') == '__Hello__'
+    assert md('<em>Hello</em>', strong_em_symbol='_') == '_Hello_'
+    assert md('<i>Hello</i>', strong_em_symbol='_') == '_Hello_'
+
+
+def test_newline_style():
+    assert md('a<br />b<br />c', newline_style=BACKSLASH) == 'a\\\nb\\\nc'

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -65,6 +65,7 @@ def test_a_no_autolinks():
 
 def test_b():
     assert md('<b>Hello</b>') == '**Hello**'
+    assert md('<b>Hello</b>', strong_em_symbol='_') == '__Hello__'
 
 
 def test_b_spaces():
@@ -89,6 +90,7 @@ def test_br():
 
 def test_em():
     assert md('<em>Hello</em>') == '*Hello*'
+    assert md('<em>Hello</em>', strong_em_symbol='_') == '_Hello_'
 
 
 def test_em_spaces():
@@ -174,6 +176,7 @@ def test_atx_closed_headings():
 
 def test_i():
     assert md('<i>Hello</i>') == '*Hello*'
+    assert md('<i>Hello</i>', strong_em_symbol='_') == '_Hello_'
 
 
 def test_ol():
@@ -187,6 +190,7 @@ def test_p():
 
 def test_strong():
     assert md('<strong>Hello</strong>') == '**Hello**'
+    assert md('<strong>Hello</strong>', strong_em_symbol='_') == '__Hello__'
 
 
 def test_ul():


### PR DESCRIPTION
Hi,

Thanks for this great package! I like it a lot, though two options I would have liked to see are the following:
1. Both symbols `*` and `_` can be used in the same manner to encode bold and italics in markdown. While they are equivalent, I thought it would be nice to be able to switch between them (this converter only uses `*`). I have added the option `strong_em_symbol` to pass the prefered symbol (defaults to `*`)
2. While `   \n` (two spaces and a newline) is the standard for encoding a line break in markdown, it not always preferred, both because it is not very visible and because many editors trim whitespaces at the end of a line. A popular alternative is to use `\\n` (a backslash and a newline), which also many interpreters support. I have added the option `newline` to the converter, which can switch to this backslash convention by setting it to `'backslash'`.

This PR achieves these things, and they have been documented in the README.