### PR TITLE
Fix missing whitespaces in <li> node

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -108,7 +108,10 @@ class MarkdownConverter(object):
 
     def process_text(self, el):
         text = six.text_type(el)
-        if el.parent.name == 'li':
+        # remove trailing whitespaces if any of the following condition is true:
+        # - current text node is the last node in li
+        # - current text node is followed by an embedded list
+        if el.parent.name == 'li' and (not el.next_sibling or el.next_sibling.name in ["ul", "ol"]):
             return escape(all_whitespace_re.sub(' ', text or '')).rstrip()
         return escape(whitespace_re.sub(' ', text or ''))
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -309,7 +309,7 @@ def test_bullets():
 
 
 def test_li_text():
-    assert md('<ul><li>foo <a href="#">bar</a></li><li>foo bar  </li></ul>') == '* foo [bar](#)\n* foo bar\n'
+    assert md('<ul><li>foo <a href="#">bar</a></li><li>foo bar  </li><li>foo <b>bar</b>   <i>space</i>.</ul>') == '* foo [bar](#)\n* foo bar\n* foo **bar** *space*.\n'
 
 
 def test_img():

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -308,6 +308,10 @@ def test_bullets():
     assert md(nested_uls, bullets='-') == '\n- 1\n\t- a\n\t\t- I\n\t\t- II\n\t\t- III\n\t- b\n\t- c\n- 2\n- 3\n'
 
 
+def test_li_text():
+    assert md('<ul><li>foo <a href="#">bar</a></li><li>foo bar  </li></ul>') == '* foo [bar](#)\n* foo bar\n'
+
+
 def test_img():
     assert md('<img src="/path/to/img.jpg" alt="Alt text" title="Optional title" />') == '![Alt text](/path/to/img.jpg "Optional title")'
     assert md('<img src="/path/to/img.jpg" alt="Alt text" />') == '![Alt text](/path/to/img.jpg)'


### PR DESCRIPTION
Fixed bug introduced in PR #23 .

```
<ul>
  <li>foo <a href="#">bar</a></li>
  <li>foo <b>bar</b> <i>space</i>.</li>
</ul>
```

is incorrectly converted to:
```
* foo[bar](#)
     ^
* foo**bar***space*.
     ^      ^
```

while it should be:
```
* foo [bar](#)
     ^
* foo **bar** *space*.
     ^       ^
```