### PR TITLE
Added language for multiline code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /MANIFEST
 /venv
 build/
+.vscode/settings.json

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -76,6 +76,7 @@ class MarkdownConverter(object):
         strong_em_symbol = ASTERISK
         sub_symbol = ''
         sup_symbol = ''
+        language = None
 
     class Options(DefaultOptions):
         pass
@@ -324,7 +325,10 @@ class MarkdownConverter(object):
     def convert_pre(self, el, text, convert_as_inline):
         if not text:
             return ''
-        return '\n```\n%s\n```\n' % text
+        if not self.options['language']:
+            return '\n```\n%s\n```\n' % text
+        else:
+            return f'\n```{self.options["language"]}\n%s\n```\n' % text
 
     convert_s = convert_del
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -210,3 +210,7 @@ def test_sub():
 def test_sup():
     assert md('<sup>foo</sup>') == 'foo'
     assert md('<sup>foo</sup>', sup_symbol='^') == '^foo^'
+
+def test_lang():
+    assert md('<pre>test\n    foo\nbar</pre>',language='python') == '\n```python\ntest\n    foo\nbar\n```\n'
+    assert md('<pre><code>test\n    foo\nbar</code></pre>',language='javascript') == '\n```javascript\ntest\n    foo\nbar\n```\n'


### PR DESCRIPTION
I've modified the code to add a parameter that enables Syntax Highlighting for multiline code and pre blocks.
This can be useful to force syntax highlighting for the whole markdown instead of having the generic markdown code block.
Example:
``` python
# Python code
md('<pre>test\n    foo\nbar</pre>',language='python') == '\n```python\ntest\n    foo\nbar\n```\n'
```
I've also added a new test to check if everything is working correctly.