### PR TITLE
setup.py: remove upper version limits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     setup_requires=[
-        'flake8>=3.8',
+        'flake8>=3.8,<5',
     ],
     tests_require=[
         'pytest>=6.2',

--- a/setup.py
+++ b/setup.py
@@ -70,13 +70,13 @@ setup(
     zip_safe=False,
     include_package_data=True,
     setup_requires=[
-        'flake8>=3.8,<4',
+        'flake8>=3.8',
     ],
     tests_require=[
-        'pytest>=6.2,<7',
+        'pytest>=6.2',
     ],
     install_requires=[
-        'beautifulsoup4>=4.9,<5', 'six>=1.15,<2'
+        'beautifulsoup4>=4.9', 'six>=1.15'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
this should be safe ...

in nixos, flake8 is currently at 4.0.1, so `flake8>=3.8,<4` is not satisfied
