### PR TITLE
Add code language callback

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -71,6 +71,7 @@ class MarkdownConverter(object):
         autolinks = True
         bullets = '*+-'  # An iterable of bullet types.
         code_language = ''
+        code_language_callback = None
         convert = None
         default_title = False
         escape_underscores = True
@@ -331,7 +332,12 @@ class MarkdownConverter(object):
     def convert_pre(self, el, text, convert_as_inline):
         if not text:
             return ''
-        return '\n```%s\n%s\n```\n' % (self.options['code_language'], text)
+        code_language = self.options['code_language']
+
+        if self.options['code_language_callback']:
+            code_language = self.options['code_language_callback'](el) or code_language
+
+        return '\n```%s\n%s\n```\n' % (code_language, text)
 
     convert_s = convert_del
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -215,3 +215,12 @@ def test_sup():
 def test_lang():
     assert md('<pre>test\n    foo\nbar</pre>', code_language='python') == '\n```python\ntest\n    foo\nbar\n```\n'
     assert md('<pre><code>test\n    foo\nbar</code></pre>', code_language='javascript') == '\n```javascript\ntest\n    foo\nbar\n```\n'
+
+
+def test_lang_callback():
+    def callback(el):
+        return el['class'][0] if el.has_attr('class') else None
+
+    assert md('<pre class="python">test\n    foo\nbar</pre>', code_language_callback=callback) == '\n```python\ntest\n    foo\nbar\n```\n'
+    assert md('<pre class="javascript"><code>test\n    foo\nbar</code></pre>', code_language_callback=callback) == '\n```javascript\ntest\n    foo\nbar\n```\n'
+    assert md('<pre class="javascript"><code class="javascript">test\n    foo\nbar</code></pre>', code_language_callback=callback) == '\n```javascript\ntest\n    foo\nbar\n```\n'


### PR DESCRIPTION
In my case I have input HTML which already has the language baked into the html element, so it would be nice to reuse that.
This way, a user can provide a callback function which can fetch the right language from an element.