### PR TITLE
Add console entry point

### DIFF
--- a/markdownify/main.py
+++ b/markdownify/main.py
@@ -1,63 +1,65 @@
 #!/usr/bin/env python
 
-import sys
 import argparse
+import sys
 
-from markdownify import *
+from markdownify import markdownify
+
 
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(
-            prog = 'markdownify',
-            description = 'Converts html to markdown.',
-            )
+        prog='markdownify',
+        description='Converts html to markdown.',
+    )
 
     parser.add_argument('html', nargs='?', type=argparse.FileType('r'),
-            default=sys.stdin,
-            help = "The html file to convert. Defaults to STDIN if not "
-            "provided.")
+                        default=sys.stdin,
+                        help="The html file to convert. Defaults to STDIN if not "
+                        "provided.")
     parser.add_argument('-s', '--strip', nargs='*',
-            help = "A list of tags to strip. This option can't be used with "
-            "the --convert option.")
+                        help="A list of tags to strip. This option can't be used with "
+                        "the --convert option.")
     parser.add_argument('-c', '--convert', nargs='*',
-            help = "A list of tags to convert. This option can't be used with "
-            "the --strip option.")
+                        help="A list of tags to convert. This option can't be used with "
+                        "the --strip option.")
     parser.add_argument('-a', '--autolinks', action='store_true',
-            help = "A boolean indicating whether the 'automatic link' style "
-            "should be used when a 'a' tag's contents match its href.")
+                        help="A boolean indicating whether the 'automatic link' style "
+                        "should be used when a 'a' tag's contents match its href.")
     parser.add_argument('--default-title', action='store_false',
-            help = "A boolean to enable setting the title of a link to its "
-            "href, if no title is given.")
+                        help="A boolean to enable setting the title of a link to its "
+                        "href, if no title is given.")
     parser.add_argument('--heading-style',
-            choices = ('ATX', 'ATX_CLOSED', 'SETEXT', 'UNDERLINED'),
-            help = "Defines how headings should be converted.")
+                        choices=('ATX', 'ATX_CLOSED', 'SETEXT', 'UNDERLINED'),
+                        help="Defines how headings should be converted.")
     parser.add_argument('-b', '--bullets', default='*+-',
-            help = "A string of bullet styles to use; the bullet will "
-            "alternate based on nesting level.")
+                        help="A string of bullet styles to use; the bullet will "
+                        "alternate based on nesting level.")
     parser.add_argument('--sub-symbol', default='',
-            help = "Define the chars that surround '<sub>'.")
+                        help="Define the chars that surround '<sub>'.")
     parser.add_argument('--sup-symbol', default='',
-            help = "Define the chars that surround '<sup>'.")
+                        help="Define the chars that surround '<sup>'.")
     parser.add_argument('--code-language', default='',
-            help = "Defines the language that should be assumed for all "
-            "'<pre>' sections.")
+                        help="Defines the language that should be assumed for all "
+                        "'<pre>' sections.")
     parser.add_argument('--no-escape-asterisks', dest='escape_asterisks',
-            action='store_false',
-            help = "Do not escape '*' to '\\*' in text.")
+                        action='store_false',
+                        help="Do not escape '*' to '\\*' in text.")
     parser.add_argument('--no-escape-underscores', dest='escape_underscores',
-            action='store_false',
-            help = "Do not escape '_' to '\\_' in text.")
+                        action='store_false',
+                        help="Do not escape '_' to '\\_' in text.")
     parser.add_argument('-i', '--keep-inline-images-in', nargs='*',
-            help = "Images are converted to their alt-text when the images are "
-            "located inside headlines or table cells. If some inline images "
-            "should be converted to markdown images instead, this option can "
-            "be set to a list of parent tags that should be allowed to "
-            "contain inline images.")
+                        help="Images are converted to their alt-text when the images are "
+                        "located inside headlines or table cells. If some inline images "
+                        "should be converted to markdown images instead, this option can "
+                        "be set to a list of parent tags that should be allowed to "
+                        "contain inline images.")
     parser.add_argument('-w', '--wrap', action='store_true',
-            help = "Wrap all text paragraphs at --wrap-width characters.")
+                        help="Wrap all text paragraphs at --wrap-width characters.")
     parser.add_argument('--wrap-width', type=int, default=80)
 
     args = parser.parse_args(argv)
     print(markdownify(**vars(args)))
+
 
 if __name__ == '__main__':
     main()

--- a/markdownify/main.py
+++ b/markdownify/main.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+
+from markdownify import *
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+            prog = 'markdownify',
+            description = 'Converts html to markdown.',
+            )
+
+    parser.add_argument('html', nargs='?', type=argparse.FileType('r'),
+            default=sys.stdin,
+            help = "The html file to convert. Defaults to STDIN if not "
+            "provided.")
+    parser.add_argument('-s', '--strip', nargs='*',
+            help = "A list of tags to strip. This option can't be used with "
+            "the --convert option.")
+    parser.add_argument('-c', '--convert', nargs='*',
+            help = "A list of tags to convert. This option can't be used with "
+            "the --strip option.")
+    parser.add_argument('-a', '--autolinks', action='store_true',
+            help = "A boolean indicating whether the 'automatic link' style "
+            "should be used when a 'a' tag's contents match its href.")
+    parser.add_argument('--default-title', action='store_false',
+            help = "A boolean to enable setting the title of a link to its "
+            "href, if no title is given.")
+    parser.add_argument('--heading-style',
+            choices = ('ATX', 'ATX_CLOSED', 'SETEXT', 'UNDERLINED'),
+            help = "Defines how headings should be converted.")
+    parser.add_argument('-b', '--bullets', default='*+-',
+            help = "A string of bullet styles to use; the bullet will "
+            "alternate based on nesting level.")
+    parser.add_argument('--sub-symbol', default='',
+            help = "Define the chars that surround '<sub>'.")
+    parser.add_argument('--sup-symbol', default='',
+            help = "Define the chars that surround '<sup>'.")
+    parser.add_argument('--code-language', default='',
+            help = "Defines the language that should be assumed for all "
+            "'<pre>' sections.")
+    parser.add_argument('--no-escape-asterisks', dest='escape_asterisks',
+            action='store_false',
+            help = "Do not escape '*' to '\\*' in text.")
+    parser.add_argument('--no-escape-underscores', dest='escape_underscores',
+            action='store_false',
+            help = "Do not escape '_' to '\\_' in text.")
+    parser.add_argument('-i', '--keep-inline-images-in', nargs='*',
+            help = "Images are converted to their alt-text when the images are "
+            "located inside headlines or table cells. If some inline images "
+            "should be converted to markdown images instead, this option can "
+            "be set to a list of parent tags that should be allowed to "
+            "contain inline images.")
+    parser.add_argument('-w', '--wrap', action='store_true',
+            help = "Wrap all text paragraphs at --wrap-width characters.")
+    parser.add_argument('--wrap-width', type=int, default=80)
+
+    args = parser.parse_args(argv)
+    print(markdownify(**vars(args)))
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -96,4 +96,9 @@ setup(
         'test': PyTest,
         'lint': LintCommand,
     },
+    entry_points={
+        'console_scripts': [
+            'markdownify = markdownify.main:main'
+        ]
+    }
 )


### PR DESCRIPTION
This allows one to use markdownify in the command line as so: `markdownify -w -s div span -- example.html > example.md`.
It also takes standard input, so you can do `<html_output> | markdownify`.

Run `markdownify -h` for all options. All made possible by the lovely `argparse`!

**P.S.** The readme needs to be updated, but you may want to do it yourself. If not let me know.