### PR TITLE
Strip text before adding blockquote markers

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -238,7 +238,7 @@ class MarkdownConverter(object):
         if convert_as_inline:
             return text
 
-        return '\n' + (line_beginning_re.sub('> ', text) + '\n\n') if text else ''
+        return '\n' + (line_beginning_re.sub('> ', text.strip()) + '\n\n') if text else ''
 
     def convert_br(self, el, text, convert_as_inline):
         if convert_as_inline:

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -52,6 +52,12 @@ def test_b_spaces():
 
 def test_blockquote():
     assert md('<blockquote>Hello</blockquote>') == '\n> Hello\n\n'
+    assert md('<blockquote>\nHello\n</blockquote>') == '\n> Hello\n\n'
+
+
+def test_blockquote_with_nested_paragraph():
+    assert md('<blockquote><p>Hello</p></blockquote>') == '\n> Hello\n\n'
+    assert md('<blockquote><p>Hello</p><p>Hello again</p></blockquote>') == '\n> Hello\n> \n> Hello again\n\n'
 
 
 def test_blockquote_with_paragraph():
@@ -60,7 +66,7 @@ def test_blockquote_with_paragraph():
 
 def test_blockquote_nested():
     text = md('<blockquote>And she was like <blockquote>Hello</blockquote></blockquote>')
-    assert text == '\n> And she was like \n> > Hello\n> \n> \n\n'
+    assert text == '\n> And she was like \n> > Hello\n\n'
 
 
 def test_br():


### PR DESCRIPTION
Hello!

@johannesdewit and I noticed there are quite a few cases where converted blockquotes generate redundant `>` markers, for example when newlines are inside the blockquote:

```pycon
In [0]: print(md("<blockquote>\nHello\n</blockquote>"))

> 
> Hello
> 
```

But also when nesting a paragraph inside a blockquote tag:

```pycon
In [1]: print(md("<blockquote><p>Hello</p></blockquote>"))

> Hello
> 
> 
```

And finally, nesting blockquotes:

```pycon
In [2]: print(md("<blockquote>And she was like <blockquote>Hello</blockquote></blockquote>"))

> And she was like 
> > Hello
> 
> 
```

If we apply a simple `.strip()` on the text before adding the blockquote markers, we can avoid these all. I have done that in this PR, and it produces these results:

```pycon
In [3]: print(md("<blockquote>\nHello\n</blockquote>"))

> Hello

In [4]: print(md("<blockquote><p>Hello</p></blockquote>"))

> Hello

In [5]: print(md("<blockquote>And she was like <blockquote>Hello</blockquote></blockquote>"))

> And she was like 
> > Hello
```

Also note that it still preserves blockquote markers between paragraphs, e.g.:

```pycon
In [6]: print(md("<blockquote><p>Hello</p><p>Hello again</p></blockquote>"))

> Hello
> 
> Hello again
```

This PR also incorporates these examples in the tests.