### PR TITLE
Fix newline start in header tags

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -266,7 +266,7 @@ class MarkdownConverter(object):
             return text
 
         style = self.options['heading_style'].lower()
-        text = text.rstrip()
+        text = text.strip()
         if style == UNDERLINED and n <= 2:
             line = '=' if n == 1 else '-'
             return self.underline(text, line)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -89,6 +89,8 @@ def test_header_with_space():
     assert md('<h3>\n\nHello</h3>') == '### Hello\n\n'
     assert md('<h4>\n\nHello</h4>') == '#### Hello\n\n'
     assert md('<h5>\n\nHello</h5>') == '##### Hello\n\n'
+    assert md('<h5>\n\nHello\n\n</h5>') == '##### Hello\n\n'
+    assert md('<h5>\n\nHello   \n\n</h5>') == '##### Hello\n\n'
 
 
 def test_h1():

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -85,6 +85,12 @@ def test_em():
     inline_tests('em', '*')
 
 
+def test_header_with_space():
+    assert md('<h3>\n\nHello</h3>') == '### Hello\n\n'
+    assert md('<h4>\n\nHello</h4>') == '#### Hello\n\n'
+    assert md('<h5>\n\nHello</h5>') == '##### Hello\n\n'
+
+
 def test_h1():
     assert md('<h1>Hello</h1>') == 'Hello\n=====\n\n'
 


### PR DESCRIPTION
Right now there is a bug with conversion of headers, starting with newline. In current implementation tag
```html
<h3>\n\nMy cool header</h3> 
```
will be converted to
```md
###
My cool header
```
which is not correct, since MD does not support multiline headers.

The tiny fix in this request will fix this issue and remove newlines in the start of header
