### PR TITLE
Fix newlines in tables

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -365,7 +365,7 @@ class MarkdownConverter(object):
         return '\n\n' + text + '\n'
 
     def convert_td(self, el, text, convert_as_inline):
-        return ' ' + text + ' |'
+        return ' ' + text.strip() + ' |'
 
     def convert_th(self, el, text, convert_as_inline):
         return ' ' + text + ' |'


### PR DESCRIPTION
A paragraph is converted as newlines around it, and this breaks the table environment in markdown.
This PR strips newlines around text in `convert_td`

Fixes https://github.com/matthewwithanm/python-markdownify/issues/90