### PR TITLE
make sure there are blank lines around table/figure captions

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -369,6 +369,12 @@ class MarkdownConverter(object):
     def convert_table(self, el, text, convert_as_inline):
         return '\n\n' + text + '\n'
 
+    def convert_caption(self, el, text, convert_as_inline):
+        return text + '\n'
+
+    def convert_figcaption(self, el, text, convert_as_inline):
+        return '\n\n' + text + '\n\n'
+
     def convert_td(self, el, text, convert_as_inline):
         return ' ' + text + ' |'
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -68,6 +68,11 @@ def test_br():
     assert md('a<br />b<br />c', newline_style=BACKSLASH) == 'a\\\nb\\\nc'
 
 
+def test_caption():
+    assert md('TEXT<figure><figcaption>Caption</figcaption><span>SPAN</span></figure>') == 'TEXT\n\nCaption\n\nSPAN'
+    assert md('<figure><span>SPAN</span><figcaption>Caption</figcaption></figure>TEXT') == 'SPAN\n\nCaption\n\nTEXT'
+
+
 def test_code():
     inline_tests('code', '`')
     assert md('<code>*this_should_not_escape*</code>') == '`*this_should_not_escape*`'

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -159,6 +159,14 @@ table_body = """<table>
     </tbody>
 </table>"""
 
+table_with_caption = """TEXT<table><caption>Caption</caption>
+    <tbody><tr><td>Firstname</td>
+            <td>Lastname</td>
+            <td>Age</td>
+        </tr>
+    </tbody>
+</table>"""
+
 
 def test_table():
     assert md(table) == '\n\n| Firstname | Lastname | Age |\n| --- | --- | --- |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |\n\n'
@@ -169,3 +177,4 @@ def test_table():
     assert md(table_missing_text) == '\n\n|  | Lastname | Age |\n| --- | --- | --- |\n| Jill |  | 50 |\n| Eve | Jackson | 94 |\n\n'
     assert md(table_missing_head) == '\n\n|  |  |  |\n| --- | --- | --- |\n| Firstname | Lastname | Age |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |\n\n'
     assert md(table_body) == '\n\n|  |  |  |\n| --- | --- | --- |\n| Firstname | Lastname | Age |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |\n\n'
+    assert md(table_with_caption) == 'TEXT\n\nCaption\n| Firstname | Lastname | Age |\n\n'


### PR DESCRIPTION
Fixes #113. Table and figure captions are now covered by unit tests.

The updated output is as follows:

```
from markdownify import markdownify as md
md('TEXT<table><caption>Caption</caption><tr><td>CELL</td></tr></tbody></table>')  # > 'TEXT\n\nCaption\n| CELL |\n\n'
                                                                                                ^^^^^^^^^

md('TEXT<figure><figcaption>Caption</figcaption><span>SPAN</span></figure>')  # > 'TEXT\n\nCaption\n\nSPAN'
#                                                                                      ^^^^^^^^^^^^^^^

md('<figure><span>SPAN</span><figcaption>Caption</figcaption></figure>TEXT')  # > 'SPAN\n\nCaption\n\nTEXT'
#                                                                                      ^^^^^^^^^^^^^^^
```