### PR TITLE
revert workaround example in README.md for `<script>` and `<style>`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,22 +173,6 @@ change:
     def md(html, **options):
         return ImageBlockConverter(**options).convert(html)
 
-.. code:: python
-
-    from markdownify import MarkdownConverter
-
-    class NoCssConverter(MarkdownConverter):
-        """
-        Create a custom MarkdownConverter that removes the CSS code by ignoring the `style` tag
-        """
-        def convert_style(self, el, text, convert_as_inline):
-            return ''
-
-    # Create shorthand method for conversion
-    def md(html, **options):
-        return NoCssConverter(**options).convert(html)
-
-
 
 Command Line Interface
 ======================


### PR DESCRIPTION
Reverts the class-based workaround for `<script>` and `<style>` in the README.rst (#111) now that the issue is fixed in the code (#112).