### PR TITLE
Special-case use of HTML tags for converting `<sub>` / `<sup>`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ strong_em_symbol
   *emphasized* texts. Either of these symbols can be chosen by the options
   ``ASTERISK`` (default) or ``UNDERSCORE`` respectively.
 
-sub_symbol, sup_symbol, sub_symbol_after, sup_symbol_after
+sub_symbol, sup_symbol
   Define the chars that surround ``<sub>`` and ``<sup>`` text. Defaults to an
   empty string, because this is non-standard behavior. Could be something like
   ``~`` and ``^`` to result in ``~sub~`` and ``^sup^``.  If the value starts

--- a/README.rst
+++ b/README.rst
@@ -87,11 +87,11 @@ strong_em_symbol
 sub_symbol, sup_symbol, sub_symbol_after, sup_symbol_after
   Define the chars that surround ``<sub>`` and ``<sup>`` text. Defaults to an
   empty string, because this is non-standard behavior. Could be something like
-  ``~`` and ``^`` to result in ``~sub~`` and ``^sup^``.  If ``sub_symbol_after``
-  and ``sup_symbol_after`` are undefined, the same string is used both before
-  and after the text.  If they are defined, different strings may be used; this
-  allow specifying ``<sub>`` and ``</sub>`` to use raw HTML in the output for
-  subscripts, for example.
+  ``~`` and ``^`` to result in ``~sub~`` and ``^sup^``.  If the value starts
+  with ``<`` and ends with ``>``, it is treated as an HTML tag and a ``/`` is
+  inserted after the ``<`` in the string used after the text; this allows
+  specifying ``<sub>`` to use raw HTML in the output for subscripts, for
+  example.
 
 newline_style
   Defines the style of marking linebreaks (``<br>``) in markdown. The default

--- a/README.rst
+++ b/README.rst
@@ -84,10 +84,14 @@ strong_em_symbol
   *emphasized* texts. Either of these symbols can be chosen by the options
   ``ASTERISK`` (default) or ``UNDERSCORE`` respectively.
 
-sub_symbol, sup_symbol
+sub_symbol, sup_symbol, sub_symbol_after, sup_symbol_after
   Define the chars that surround ``<sub>`` and ``<sup>`` text. Defaults to an
   empty string, because this is non-standard behavior. Could be something like
-  ``~`` and ``^`` to result in ``~sub~`` and ``^sup^``.
+  ``~`` and ``^`` to result in ``~sub~`` and ``^sup^``.  If ``sub_symbol_after``
+  and ``sup_symbol_after`` are undefined, the same string is used both before
+  and after the text.  If they are defined, different strings may be used; this
+  allow specifying ``<sub>`` and ``</sub>`` to use raw HTML in the output for
+  subscripts, for example.
 
 newline_style
   Defines the style of marking linebreaks (``<br>``) in markdown. The default

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -39,21 +39,24 @@ def chomp(text):
     return (prefix, suffix, text)
 
 
-def abstract_inline_conversion(markup_fn):
+def abstract_inline_conversion(markup_fn, markup_fn_after=None):
     """
     This abstracts all simple inline tags like b, em, del, ...
     Returns a function that wraps the chomped text in a pair of the string
-    that is returned by markup_fn. markup_fn is necessary to allow for
-    references to self.strong_em_symbol etc.
+    that is returned by markup_fn, or the string from markup_fn before the
+    chomped text and the string from markup_fn_after after it if markup_fn_after
+    is defined. markup_fn is necessary to allow for references to
+    self.strong_em_symbol etc.
     """
     def implementation(self, el, text, convert_as_inline):
         markup = markup_fn(self)
+        markup_after = markup_fn_after(self) if markup_fn_after else markup
         if el.find_parent(['pre', 'code', 'kbd', 'samp']):
             return text
         prefix, suffix, text = chomp(text)
         if not text:
             return ''
-        return '%s%s%s%s%s' % (prefix, markup, text, markup, suffix)
+        return '%s%s%s%s%s' % (prefix, markup, text, markup_after, suffix)
     return implementation
 
 
@@ -79,6 +82,8 @@ class MarkdownConverter(object):
         strong_em_symbol = ASTERISK
         sub_symbol = ''
         sup_symbol = ''
+        sub_symbol_after = None
+        sup_symbol_after = None
         wrap = False
         wrap_width = 80
 
@@ -368,9 +373,13 @@ class MarkdownConverter(object):
 
     convert_samp = convert_code
 
-    convert_sub = abstract_inline_conversion(lambda self: self.options['sub_symbol'])
+    convert_sub = abstract_inline_conversion(
+        lambda self: self.options['sub_symbol'],
+        lambda self: self.options['sub_symbol_after'] if self.options['sub_symbol_after'] is not None else self.options['sub_symbol'])
 
-    convert_sup = abstract_inline_conversion(lambda self: self.options['sup_symbol'])
+    convert_sup = abstract_inline_conversion(
+        lambda self: self.options['sup_symbol'],
+        lambda self: self.options['sup_symbol_after'] if self.options['sup_symbol_after'] is not None else self.options['sup_symbol'])
 
     def convert_table(self, el, text, convert_as_inline):
         return '\n\n' + text + '\n'

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -268,11 +268,13 @@ def test_strong_em_symbol():
 def test_sub():
     assert md('<sub>foo</sub>') == 'foo'
     assert md('<sub>foo</sub>', sub_symbol='~') == '~foo~'
+    assert md('<sub>foo</sub>', sub_symbol='<sub>', sub_symbol_after='</sub>') == '<sub>foo</sub>'
 
 
 def test_sup():
     assert md('<sup>foo</sup>') == 'foo'
     assert md('<sup>foo</sup>', sup_symbol='^') == '^foo^'
+    assert md('<sup>foo</sup>', sup_symbol='<sup>', sup_symbol_after='</sup>') == '<sup>foo</sup>'
 
 
 def test_lang():

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -268,13 +268,13 @@ def test_strong_em_symbol():
 def test_sub():
     assert md('<sub>foo</sub>') == 'foo'
     assert md('<sub>foo</sub>', sub_symbol='~') == '~foo~'
-    assert md('<sub>foo</sub>', sub_symbol='<sub>', sub_symbol_after='</sub>') == '<sub>foo</sub>'
+    assert md('<sub>foo</sub>', sub_symbol='<sub>') == '<sub>foo</sub>'
 
 
 def test_sup():
     assert md('<sup>foo</sup>') == 'foo'
     assert md('<sup>foo</sup>', sup_symbol='^') == '^foo^'
-    assert md('<sup>foo</sup>', sup_symbol='<sup>', sup_symbol_after='</sup>') == '<sup>foo</sup>'
+    assert md('<sup>foo</sup>', sup_symbol='<sup>') == '<sup>foo</sup>'
 
 
 def test_lang():


### PR DESCRIPTION
Special-case use of HTML tags for `sub_symbol` and `sup_symbol`. In particular, this allows setting `sub_symbol='<sub>'`, `sup_symbol='<sup>'` to use raw HTML in the output when converting subscripts and superscripts.