### PR TITLE
be more selective about escaping special characters

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -202,13 +202,36 @@ class MarkdownConverter(object):
     def escape(self, text):
         if not text:
             return ''
+
         if self.options['escape_misc']:
-            text = re.sub(r'([\\&<`[>~#=+|-])', r'\\\1', text)
-            text = re.sub(r'([0-9])([.)])', r'\1\\\2', text)
+            # add escaping to all '<', '[', '\', '|' characters
+            text = re.sub(r'([<[\\|])', r'\\\1', text)
+
+            # add escaping to '#' characters with Markdown significance
+            text = re.sub(r'^(#+ )', r'\\\1', text, flags=re.MULTILINE)
+            # add escaping to '&' characters that could be misinterpreted as HTML entities
+            text = re.sub(r'(&)(?=#?\w+;)', r'\\\1', text)
+            # add escaping to '+' characters with Markdown significance
+            text = re.sub(r'^( *)(\+ )', r'\1\\\2', text, flags=re.MULTILINE)
+            # add escaping to '-' characters with Markdown significance
+            text = re.sub(r'(^ *|(?<!-)(?=-{2,3}(?!-)))(-)', r'\1\\\2', text, flags=re.MULTILINE)
+            # add escaping to '=' characters with Markdown significance
+            text = re.sub(r'(^=+$|(?<!=)={2,}(?!=))', r'\\\1', text, flags=re.MULTILINE)
+            # add escaping to '>' characters with Markdown significance
+            text = re.sub(r'^( *)(> )', r'\1\\\2', text, flags=re.MULTILINE)
+            # add escaping to '`' characters with Markdown significance
+            text = re.sub(r'(^`{3,}|`)', r'\\\1', text, flags=re.MULTILINE)
+            # add escaping to '~' characters with Markdown significance
+            text = re.sub(r'(^~{3,}|~)', r'\\\1', text, flags=re.MULTILINE)
+            # add escaping to avoid mis-inferred Markdown ordered list items
+            text = re.sub(r'^( *\d+)([.)] )', r'\1\\\2', text, flags=re.MULTILINE)
+
+        # these are separately controlled for legacy reasons
         if self.options['escape_asterisks']:
             text = text.replace('*', r'\*')
         if self.options['escape_underscores']:
             text = text.replace('_', r'\_')
+
         return text
 
     def indent(self, text, level):

--- a/tests/test_escaping.py
+++ b/tests/test_escaping.py
@@ -12,7 +12,7 @@ def test_underscore():
 
 
 def test_xml_entities():
-    assert md('&amp;') == r'\&'
+    assert md('&amp;') == r'&'
 
 
 def test_named_entities():
@@ -28,20 +28,77 @@ def test_single_escaping_entities():
     assert md('&amp;amp;') == r'\&amp;'
 
 
-def text_misc():
-    assert md('\\*') == r'\\\*'
-    assert md('<foo>') == r'\<foo\>'
-    assert md('# foo') == r'\# foo'
-    assert md('> foo') == r'\> foo'
-    assert md('~~foo~~') == r'\~\~foo\~\~'
-    assert md('foo\n===\n') == 'foo\n\\=\\=\\=\n'
-    assert md('---\n') == '\\-\\-\\-\n'
-    assert md('+ x\n+ y\n') == '\\+ x\n\\+ y\n'
-    assert md('`x`') == r'\`x\`'
-    assert md('[text](link)') == r'\[text](link)'
-    assert md('1. x') == r'1\. x'
-    assert md('not a number. x') == r'not a number. x'
-    assert md('1) x') == r'1\) x'
-    assert md('not a number) x') == r'not a number) x'
-    assert md('|not table|') == r'\|not table\|'
-    assert md(r'\ <foo> &amp;amp; | ` `', escape_misc=False) == r'\ <foo> &amp; | ` `'
+def test_escape_misc_chars():
+    assert md('[yes](link)') == '\\[yes](link)'
+    assert md('&lt;yes&gt;') == '\\<yes>'
+    assert md('\\yes') == '\\\\yes'
+    assert md('*yes') == '\\*yes'
+
+    assert md('\\ &lt;foo> &amp;amp; | ` `', escape_misc=False) == '\\ <foo> &amp; | ` `'
+
+
+def test_escape_misc_hash():
+    assert md('# yes\n## yes') == '\\# yes\n\\## yes'
+    assert md(' # no\n ## no') == ' # no\n ## no'
+
+
+def test_escape_misc_ampersand():
+    assert md('&amp;yes;') == '\\&yes;'
+    assert md('& no') == '& no'
+
+
+def test_escape_misc_plus():
+    assert md('+ yes\n + yes\n') == '\\+ yes\n \\+ yes\n'
+    assert md('no+no\nno + no\n') == 'no+no\nno + no\n'
+
+
+def test_escape_misc_hyphen():
+    assert md('---\n') == '\\---\n'
+    assert md('- yes\n - yes') == '\\- yes\n \\- yes'
+    assert md('no-\n') == 'no-\n'
+    assert md('yes--\n') == 'yes\\--\n'
+    assert md('yes---\n') == 'yes\\---\n'
+    assert md('no----\n') == 'no----\n'
+
+
+def test_escape_misc_equals():
+    assert md('yes\n=\n') == 'yes\n\\=\n'
+    assert md('yes\n===\n') == 'yes\n\\===\n'
+    assert md('no\n =\n') == 'no\n =\n'
+    assert md('no=no') == 'no=no'
+    assert md('yes==yes') == 'yes\\==yes'
+    assert md('yes===yes') == 'yes\\===yes'
+
+
+def test_escape_misc_greaterthan():
+    assert md('> yes\n > yes') == '\\> yes\n \\> yes'
+    assert md('>no\n >no') == '>no\n >no'
+
+
+def test_escape_misc_backtick():
+    assert md('```\n```yes') == '\\```\n\\```yes'
+    assert md('``````\n``````yes') == '\\``````\n\\``````yes'
+    assert md('`yes`\n `yes`') == '\\`yes\\`\n \\`yes\\`'
+
+
+def test_escape_misc_pipe():
+    assert md('|') == '\\|'
+    assert md('|-|') == '\\|-\\|'
+    assert md('| ---- |') == '\\| ---- \\|'
+    assert md('|yes|') == '\\|yes\\|'
+    assert md('| yes |') == '\\| yes \\|'
+
+
+def test_escape_misc_tilde():
+    assert md(' ~yes~') == ' \\~yes\\~'
+    assert md(' ~~yes~~') == ' \\~\\~yes\\~\\~'
+    assert md('~~~\n~~~yes\n') == '\\~~~\n\\~~~yes\n'
+
+
+def test_escape_misc_listitems():
+    assert md('1. yes\n 1. yes') == '1\\. yes\n 1\\. yes'
+    assert md('1) yes\n 1) yes') == '1\\) yes\n 1\\) yes'
+    assert md('1.no\n 1.no') == '1.no\n 1.no'
+    assert md('1)no\n 1)no') == '1)no\n 1)no'
+    assert md('no1. x\n no1. y') == 'no1. x\n no1. y'
+    assert md('no1) x\n no1) y') == 'no1) x\n no1) y'


### PR DESCRIPTION
This is a refinement of #118 (thanks @jsm28!).

The current solution escapes every instance of every special character. Although conservative, this can lead to unnecessary escaping. For example,

```
>>> from markdownify import markdownify as md

>>> md('Pick a color (just 1) to use.')
'Pick a color (just 1\\) to use.'

>>> md('Pick a color, just 1. Write it down.')
'Pick a color, just 1\\. Write it down.'

>>> md('1 + 1 = 2')
'1 \\+ 1 \\= 2'

>>> md('start ----> end')
'start \\-\\-\\-\\-\\> end'
```

In our use case, our input content is technical documentation (many special characters) and the content is subsequently edited by humans, so it is desirable to minimize unnecessary escaping.

This pull request seeks to strike a balance between the following:

- Maximizing required escaping
- Minimizing unnecessary escaping
- Minimizing code complexity
- Minimizing runtime penalty (about 25% overall)

The tests cover a variety of required and unnecessary escaping cases, which can hopefully avoid any future regressions in escaping behavior.

This approach is not foolproof. Markdownify processes each text fragment in isolation, and thus the beginning of a particular string might not be the beginning of an output line. As a result, patterns are not applied across text fragment boundaries (such as adjacent `<span>` elements). Handling this probably requires a larger rework of the text processing code.

I also noticed that the original code had `def text_misc()` instead of `def test_misc()`, which caused the tests never to run.