### PR TITLE
Update MANIFEST.in to exclude tests during packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+prune tests


### PR DESCRIPTION
Closes #86

Currently the published package adds  `tests` to site packages on anyone that installs this library. This can cause problems when you have `markdownify` installed as a library but also have a `tests` module on your own project, which is quite common place to put tests.

Alternative solution is to use `find_packages(exclude=['tests'])` but thay may affect your local development setup, so I opted for updating `MANIFEST.in` instead which has mostly relevance at publish time and does not affect local development.