### PR TITLE
for convert_* functions, allow for tags with special characters in their name (like "subtag-name")

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -172,7 +172,8 @@ class MarkdownConverter(object):
                 text = text_strip + newlines + next_text_strip
 
         if not children_only:
-            convert_fn = getattr(self, 'convert_%s' % node.name, None)
+            fn_name = 'convert_%s' % node.name.translate(''.maketrans(':-', '__'))
+            convert_fn = getattr(self, fn_name, None)
             if convert_fn and self.should_convert_tag(node.name):
                 text = convert_fn(node, text, convert_as_inline)
 

--- a/tests/test_custom_converter.py
+++ b/tests/test_custom_converter.py
@@ -2,21 +2,28 @@ from markdownify import MarkdownConverter
 from bs4 import BeautifulSoup
 
 
-class ImageBlockConverter(MarkdownConverter):
+class UnitTestConverter(MarkdownConverter):
     """
-    Create a custom MarkdownConverter that adds two newlines after an image
+    Create a custom MarkdownConverter for unit tests
     """
     def convert_img(self, el, text, convert_as_inline):
+        """Add two newlines after an image"""
         return super().convert_img(el, text, convert_as_inline) + '\n\n'
 
+    def convert_custom_tag(self, el, text, convert_as_inline):
+        """Ensure conversion function is found for tags with special characters in name"""
+        return "FUNCTION USED: %s" % text
 
-def test_img():
+
+def test_custom_conversion_functions():
     # Create shorthand method for conversion
     def md(html, **options):
-        return ImageBlockConverter(**options).convert(html)
+        return UnitTestConverter(**options).convert(html)
 
     assert md('<img src="/path/to/img.jpg" alt="Alt text" title="Optional title" />') == '![Alt text](/path/to/img.jpg "Optional title")\n\n'
     assert md('<img src="/path/to/img.jpg" alt="Alt text" />') == '![Alt text](/path/to/img.jpg)\n\n'
+
+    assert md("<custom-tag>text</custom-tag>") == "FUNCTION USED: text"
 
 
 def test_soup():


### PR DESCRIPTION
html tags may contain symbols like `:` and `-` which are not suitable for the python function names
simple name converter allows usage of the methods for tags like `tag:subtag-name`