### PR TITLE
Create py.typed

### DIFF
--- a/markdownify/py.typed
+++ b/markdownify/py.typed
@@ -1,0 +1,1 @@
+# typing sentinel, see: https://peps.python.org/pep-0561/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ description = "Convert HTML to markdown."
 readme = "README.rst"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -20,7 +19,14 @@ classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Text Processing :: Markup :: HTML",
     "Topic :: Utilities",
+    "Typing :: Typed",
 ]
 dependencies = [
     "beautifulsoup4>=4.9,<5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,7 @@ include-package-data = true
 include = ["markdownify", "markdownify.*"]
 namespaces = false
 
+[tool.setuptools.package-data]
+"markdownify" = ["py.typed"]
+
 [tool.setuptools_scm]


### PR DESCRIPTION
This PR adds typing support to this package. Without the py.typed file the package is considered untyped. 

See: https://peps.python.org/pep-0561/

This will resolve MyPy and other type-checking errors like this:

```shell
src/main.py:13: error: Skipping analyzing "markdownify": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/main.py:13: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

I also took the liberty of updating your PyPi classifiers 😉 