### PR TITLE
Escape right square bracket

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -208,7 +208,7 @@ class MarkdownConverter(object):
         if not text:
             return ''
         if self.options['escape_misc']:
-            text = re.sub(r'([\\&<`[>~#=+|-])', r'\\\1', text)
+            text = re.sub(r'([\\&<`[\]>~#=+|-])', r'\\\1', text)
             text = re.sub(r'([0-9])([.)])', r'\1\\\2', text)
         if self.options['escape_asterisks']:
             text = text.replace('*', r'\*')


### PR DESCRIPTION
Add the right square bracket (]) to the list of escaped symbols. This is necessary to correctly represent a link text containing a right square bracket:

```python

html = '<a href="citation.html">[How to cite this work]</a>'
print(markdownify(html))

# before this pr: r'[\[How to cite this work]](citation.html)'
# after this pr:  r'[\[How to cite this work\]](citation.html)'

```