### PR TITLE
perf: improve parsing performance from o(n^2) to o(n)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 build/
 .vscode/settings.json
 .tox/
+.python-version

--- a/tests/test_newlines.py
+++ b/tests/test_newlines.py
@@ -1,0 +1,39 @@
+from markdownify import markdownify as md
+
+
+html = """
+<article>
+    <h1>Heading 1</h1>
+    <div>
+        <p>article body</p>
+    </div>
+    <article>
+        <h2>Heading 2</h2>
+        <div>
+            <p>article body</p>
+        </div>
+    </article>
+    <p>footnote</p>
+</article>
+"""
+
+# Leaving this here just for reference.
+correct_conversion = """Heading 1
+=========
+
+article body
+
+
+Heading 2
+---------
+
+article body
+
+
+footnote"""
+
+
+def test_newlines():
+    converted = md(html)
+    newlines = converted.count('\n')
+    assert newlines == 12


### PR DESCRIPTION
The function `process_tag` was previously concatenating strings inside of a loop. Each + operation creates a new string, resulting in repeated copying of already accumulated data. This logic is of complexity O(n<sup>2</sup>).

We can take this from an exponential function to a linear function by using an array, appending to it, and then returning a `''.join()` at the end. This logic is of complexity O(n).

After this change, the time it took to convert a 20.8MB HTML file (_US social security tax law document_) went from **18.94 minutes** to **4.11 minutes**, a speed increase of 4.6x.

```shell
# Before change
Converting title_42—the_public_health_and_welfare::chapter_7—social_security.html to markdown...
Writing title_42—the_public_health_and_welfare::chapter_7—social_security.md...
Time taken: 1136.8312180042267 seconds

# After change
Converting title_42—the_public_health_and_welfare::chapter_7—social_security.html to markdown...
Writing title_42—the_public_health_and_welfare::chapter_7—social_security.md...
Time taken: 246.62110209465027 seconds
```

All `tox` tests are also passing. 

I also added .python-version to the .gitignore file, (_I was using pyenv_)