### PR TITLE
do not construct Markdown links in code spans and code blocks

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -264,6 +264,8 @@ class MarkdownConverter(object):
         return '\n\n%s\n%s\n\n' % (text, pad_char * len(text)) if text else ''
 
     def convert_a(self, el, text, convert_as_inline):
+        if el.find_parent(['pre', 'code', 'kbd', 'samp']):
+            return text
         prefix, suffix, text = chomp(text)
         if not text:
             return ''

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -39,6 +39,11 @@ def test_a_no_autolinks():
     assert md('<a href="https://google.com">https://google.com</a>', autolinks=False) == '[https://google.com](https://google.com)'
 
 
+def test_a_in_code():
+    assert md('<code><a href="https://google.com">Google</a></code>') == '`Google`'
+    assert md('<pre><a href="https://google.com">Google</a></pre>') == '\n```\nGoogle\n```\n'
+
+
 def test_b():
     assert md('<b>Hello</b>') == '**Hello**'
 


### PR DESCRIPTION
Fixes #164.

The `convert_a()` function is modified to return only the contents of `<a>` in code spans and code blocks, effectively disabling link construction in these contexts.

Unit tests are added to cover this case.