### PR TITLE
insert a blank line between table caption, table content

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -442,7 +442,7 @@ class MarkdownConverter(object):
         return '\n\n' + text + '\n'
 
     def convert_caption(self, el, text, convert_as_inline):
-        return text + '\n'
+        return text + '\n\n'
 
     def convert_figcaption(self, el, text, convert_as_inline):
         return '\n\n' + text + '\n\n'

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -249,6 +249,6 @@ def test_table():
     assert md(table_missing_text) == '\n\n|  | Lastname | Age |\n| --- | --- | --- |\n| Jill |  | 50 |\n| Eve | Jackson | 94 |\n\n'
     assert md(table_missing_head) == '\n\n| Firstname | Lastname | Age |\n| --- | --- | --- |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |\n\n'
     assert md(table_body) == '\n\n| Firstname | Lastname | Age |\n| --- | --- | --- |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |\n\n'
-    assert md(table_with_caption) == 'TEXT\n\nCaption\n| Firstname | Lastname | Age |\n| --- | --- | --- |\n\n'
+    assert md(table_with_caption) == 'TEXT\n\nCaption\n\n| Firstname | Lastname | Age |\n| --- | --- | --- |\n\n'
     assert md(table_with_colspan) == '\n\n| Name | | Age |\n| --- | --- | --- |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |\n\n'
     assert md(table_with_undefined_colspan) == '\n\n| Name | Age |\n| --- | --- |\n| Jill | Smith |\n\n'


### PR DESCRIPTION
Fixes #166.

The `convert_caption()` function is modified to add an additional trailing newline.

The unit tests are updated to cover this change.