### PR TITLE
optimize empty-line handling for li and blockquote content

### DIFF
--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -62,7 +62,7 @@ def test_blockquote():
 
 def test_blockquote_with_nested_paragraph():
     assert md('<blockquote><p>Hello</p></blockquote>') == '\n> Hello\n\n'
-    assert md('<blockquote><p>Hello</p><p>Hello again</p></blockquote>') == '\n> Hello\n> \n> Hello again\n\n'
+    assert md('<blockquote><p>Hello</p><p>Hello again</p></blockquote>') == '\n> Hello\n>\n> Hello again\n\n'
 
 
 def test_blockquote_with_paragraph():

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -47,7 +47,7 @@ def test_ol():
     assert md('<ol start="-1"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
     assert md('<ol start="foo"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
     assert md('<ol start="1.5"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
-    assert md('<ol start="1234"><li><p>first para</p><p>second para</p></li><li><p>third para</p><p>fourth para</p></li></ol>') == '\n\n1234. first para\n      \n      second para\n1235. third para\n      \n      fourth para\n'
+    assert md('<ol start="1234"><li><p>first para</p><p>second para</p></li><li><p>third para</p><p>fourth para</p></li></ol>') == '\n\n1234. first para\n\n      second para\n1235. third para\n\n      fourth para\n'
 
 
 def test_nested_ols():
@@ -64,7 +64,7 @@ def test_ul():
      <li>   c
      </li>
  </ul>""") == '\n\n* a\n* b\n* c\n'
-    assert md('<ul><li><p>first para</p><p>second para</p></li><li><p>third para</p><p>fourth para</p></li></ul>') == '\n\n* first para\n  \n  second para\n* third para\n  \n  fourth para\n'
+    assert md('<ul><li><p>first para</p><p>second para</p></li><li><p>third para</p><p>fourth para</p></li></ul>') == '\n\n* first para\n\n  second para\n* third para\n\n  fourth para\n'
 
 
 def test_inline_ul():


### PR DESCRIPTION
Fixes #170.

The `convert_li()` and `convert_blockquote()` functions are updated to use "substitution functions" to compute how each line should be modified. Inside the functions, different actions are taken for content lines versus empty lines.

For example (spaces replaced with `·` in output):

```python
from markdownify import markdownify as md

html = """
<blockquote>
  <ul>
    <li>
      <p>1</p>
      <ul>
        <li>
          <p>1-a</p>
          <p>2-b</p>
        </li>
      <ul>
    </li>
    <li>
      <p>2</p>
    </li>
  </ul>
</blockquote>
"""
print(md(html, wrap=True, wrap_width=1e8))
# >·*·1
# >
# >···+·1-a
# >
# >·····2-b
# >·*·2
```

Unit tests are updated to reflect the changes. In addition, manual tests were performed by using Pandoc to convert the Markdown back to HTML to verify correctness.