### PR TITLE
support HTML definition lists (`<dl>`, `<dt>`, and `<dd>`)

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -319,6 +319,38 @@ class MarkdownConverter(object):
 
     convert_kbd = convert_code
 
+    def convert_dd(self, el, text, convert_as_inline):
+        text = (text or '').strip()
+        if convert_as_inline:
+            return ' ' + text + ' '
+        if not text:
+            return '\n'
+
+        # indent definition content lines by four spaces
+        def _indent_for_dd(match):
+            line_content = match.group(1)
+            return '    ' + line_content if line_content else ''
+        text = line_with_content_re.sub(_indent_for_dd, text)
+
+        # insert definition marker into first-line indent whitespace
+        text = ':' + text[1:]
+
+        return '%s\n' % text
+
+    def convert_dt(self, el, text, convert_as_inline):
+        # remove newlines from term text
+        text = (text or '').strip()
+        text = all_whitespace_re.sub(' ', text)
+        if convert_as_inline:
+            return ' ' + text + ' '
+        if not text:
+            return '\n'
+
+        # TODO - format consecutive <dt> elements as directly adjacent lines):
+        #   https://michelf.ca/projects/php-markdown/extra/#def-list
+
+        return '\n%s\n' % text
+
     def _convert_hn(self, n, el, text, convert_as_inline):
         """ Method name prefixed with _ to prevent <hn> to call this """
         if convert_as_inline:

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -104,6 +104,16 @@ def test_code():
     assert md('<code>foo<sub>bar</sub>baz</code>', sub_symbol='^') == '`foobarbaz`'
 
 
+def test_dl():
+    assert md('<dl><dt>term</dt><dd>definition</dd></dl>') == '\nterm\n:   definition\n'
+    assert md('<dl><dt><p>te</p><p>rm</p></dt><dd>definition</dd></dl>') == '\nte rm\n:   definition\n'
+    assert md('<dl><dt>term</dt><dd><p>definition-p1</p><p>definition-p2</p></dd></dl>') == '\nterm\n:   definition-p1\n\n    definition-p2\n'
+    assert md('<dl><dt>term</dt><dd><p>definition 1</p></dd><dd><p>definition 2</p></dd></dl>') == '\nterm\n:   definition 1\n:   definition 2\n'
+    assert md('<dl><dt>term 1</dt><dd>definition 1</dd><dt>term 2</dt><dd>definition 2</dd></dl>') == '\nterm 1\n:   definition 1\nterm 2\n:   definition 2\n'
+    assert md('<dl><dt>term</dt><dd><blockquote><p>line 1</p><p>line 2</p></blockquote></dd></dl>') == '\nterm\n:   > line 1\n    >\n    > line 2\n'
+    assert md('<dl><dt>term</dt><dd><ol><li><p>1</p><ul><li>2a</li><li>2b</li></ul></li><li><p>3</p></li></ol></dd></dl>') == '\nterm\n:   1. 1\n\n       * 2a\n       * 2b\n    2. 3\n'
+
+
 def test_del():
     inline_tests('del', '~~')
 


### PR DESCRIPTION
Fixes #172.

New `convert_dt()` and `convert_dd()` functions are added that follow the PHP Markdown Extra syntax:

https://michelf.ca/projects/php-markdown/extra/#def-list

If additional definition list dialects are requested in the future, a configuration option can be added to select the format.

No `convert_dl()` function is added; the child-tag conversion functions do all the work.

The regression tests are updated to test various structures. I also used Pandoc to confirm that all Markdownify results are converted back to the expected HTML source.

**Note**: This pull request requires that #171 be merged first; otherwise the `test_dl` unit test will fail.

## Limitations

There are two limitations in this support, both related to the fact that blank lines are added outside the `convert_dt()` and `convert_dd()` function scopes.

Limitation 1 - multiple terms sharing the same definition are not handled properly (the term lines are separated by a blank line instead of kept directly adjacent):

```html
<dl>
  <dt>term 1a</dt>
  <dt>term 1b</dt>
  <dd>definition</dd>
</dl>
```

Limitation 2 - a blank line is always inserted before definitions, causing them to signify paragraph-based definitions even when they were not:

```html
<dl>
  <dt>term 1</dt>
  <dd>bare definition</dd>
  <dt>term 2</dt>
  <dd><p>definition in paragraph</p></dd>
</dl>
```