### PR TITLE
simplify computation of convert_children_as_inline variable

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -135,14 +135,13 @@ class MarkdownConverter(object):
     def process_tag(self, node, convert_as_inline):
         text = ''
 
-        # markdown headings or cells can't include
-        # block elements (elements w/newlines)
-        isHeading = html_heading_re.match(node.name) is not None
-        isCell = node.name in ['td', 'th']
-        convert_children_as_inline = convert_as_inline
-
-        if isHeading or isCell:
-            convert_children_as_inline = True
+        # For Markdown headings and table cells, convert children as inline
+        # (so that block element children do not produce newlines).
+        convert_children_as_inline = (
+            convert_as_inline  # propagated from parent
+            or html_heading_re.match(node.name) is not None  # headings
+            or node.name in ['td', 'th']  # table cells
+        )
 
         # Remove whitespace-only textnodes just before, after or
         # inside block-level elements.


### PR DESCRIPTION
Simplifies the computation of the `convert_children_as_inline`:

* Intermediate variables are replaced with a single short-circuiting expression.
* First consideration is given to the incoming `convert_as_inline` flag.