### PR TITLE
when computing <ol><li> numbering, ignore non-<li> previous siblings

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -444,7 +444,7 @@ class MarkdownConverter(object):
                 start = int(parent.get("start"))
             else:
                 start = 1
-            bullet = '%s.' % (start + parent.index(el))
+            bullet = '%s.' % (start + len(el.find_previous_siblings('li')))
         else:
             depth = -1
             while el:

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -42,6 +42,7 @@ nested_ols = """
 
 def test_ol():
     assert md('<ol><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
+    assert md('<ol><!--comment--><li>a</li><span/><li>b</li></ol>') == '\n\n1. a\n2. b\n'
     assert md('<ol start="3"><li>a</li><li>b</li></ol>') == '\n\n3. a\n4. b\n'
     assert md('foo<ol start="3"><li>a</li><li>b</li></ol>bar') == 'foo\n\n3. a\n4. b\n\nbar'
     assert md('<ol start="-1"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'


### PR DESCRIPTION
Currently, numbering for `<li>` items inside `<ol>` count *all* previous siblings when computing the number:

```python
import markdownify

html = """
<ol>
  <!--comment-->
  <li>a</li>
  <div/>
  <li>b</li>
</ol>
"""

print(markdownify.MarkdownConverter().convert(html))
# 2. a
# 4. b
```

This pull request updates the code to consider only preceding `<li>` elements:

```python
print(markdownify.MarkdownConverter().convert(html))
# 1. a
# 2. b
```

A unit test is added to check this case.