### PR TITLE
propagate parent tag context downward to improve runtime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,7 +180,7 @@ If you have a special usecase that calls for a special conversion, you can
 always inherit from ``MarkdownConverter`` and override the method you want to
 change.
 The function that handles a HTML tag named ``abc`` is called
-``convert_abc(self, el, text, convert_as_inline)`` and returns a string
+``convert_abc(self, el, text, parent_tags)`` and returns a string
 containing the converted HTML tag.
 The ``MarkdownConverter`` object will handle the conversion based on the
 function names:
@@ -193,8 +193,8 @@ function names:
         """
         Create a custom MarkdownConverter that adds two newlines after an image
         """
-        def convert_img(self, el, text, convert_as_inline):
-            return super().convert_img(el, text, convert_as_inline) + '\n\n'
+        def convert_img(self, el, text, parent_tags):
+            return super().convert_img(el, text, parent_tags) + '\n\n'
 
     # Create shorthand method for conversion
     def md(html, **options):
@@ -208,7 +208,7 @@ function names:
         """
         Create a custom MarkdownConverter that ignores paragraphs
         """
-        def convert_p(self, el, text, convert_as_inline):
+        def convert_p(self, el, text, parent_tags):
             return ''
 
     # Create shorthand method for conversion

--- a/tests/test_custom_converter.py
+++ b/tests/test_custom_converter.py
@@ -6,11 +6,11 @@ class UnitTestConverter(MarkdownConverter):
     """
     Create a custom MarkdownConverter for unit tests
     """
-    def convert_img(self, el, text, convert_as_inline):
+    def convert_img(self, el, text, parent_tags):
         """Add two newlines after an image"""
-        return super().convert_img(el, text, convert_as_inline) + '\n\n'
+        return super().convert_img(el, text, parent_tags) + '\n\n'
 
-    def convert_custom_tag(self, el, text, convert_as_inline):
+    def convert_custom_tag(self, el, text, parent_tags):
         """Ensure conversion function is found for tags with special characters in name"""
         return "FUNCTION USED: %s" % text
 


### PR DESCRIPTION
Fixes #190.

Improves runtime by propagating the parent tag context downward into children. Python `set()` objects are used because membership tests are fast and deduplication is automatic.

In addition, the following "pseudo-parent" parent tag names are propagated:

* `_inline` - parent include a heading, `td`, or `th` tag
* `_noformat` - parents include a `pre`, `code`, `kbd`, or `samp` tag

For one of my large HTML testcases that has `<div>`, `<article>`, and `<section>` hierarchy, runtime improves from 502 seconds to 261 seconds.

This pull request changes the interface for `convert_*()` functions by changing the `convert_as_inline` Boolean parameter to a `parent_tags` set parameter, so this change should probably be made in a major version number change.