### PR TITLE
in inline contexts, resolve <br/> to a space instead of an empty string

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -443,7 +443,7 @@ class MarkdownConverter(object):
 
     def convert_br(self, el, text, parent_tags):
         if '_inline' in parent_tags:
-            return ""
+            return ' '
 
         if self.options['newline_style'].lower() == BACKSLASH:
             return '\\\n'

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -79,6 +79,8 @@ def test_blockquote_nested():
 def test_br():
     assert md('a<br />b<br />c') == 'a  \nb  \nc'
     assert md('a<br />b<br />c', newline_style=BACKSLASH) == 'a\\\nb\\\nc'
+    assert md('<h1>foo<br />bar</h1>', heading_style=ATX) == '\n\n# foo bar\n\n'
+    assert md('<td>foo<br />bar</td>', heading_style=ATX) == ' foo bar |'
 
 
 def test_code():


### PR DESCRIPTION
Fixes #201. In inline contexts, `<br />` now resolves to a space instead of an empty string.

Unit tests were added to include this case.