### PR TITLE
Add beautiful_soup_parser option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,12 +73,6 @@ heading_style
   ``ATX_CLOSED``, ``SETEXT``, and ``UNDERLINED`` (which is an alias for
   ``SETEXT``). Defaults to ``UNDERLINED``.
 
-beautiful_soup_parser
-  Specifies the HTML parser to be used by
-  [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/).
-  Values such as ``html5lib``, ``lxml`` can be used but require those parser
-  to be installed in your project. Defaults to ``html.parser``.
-
 bullets
   An iterable (string, list, or tuple) of bullet styles to be used. If the
   iterable only contains one item, it will be used regardless of how deeply
@@ -162,6 +156,13 @@ strip_document
   ``RSTRIP`` (trailing), ``STRIP`` (both), and ``None`` (neither). Newlines
   within the document are unaffected.
   Defaults to ``STRIP``.
+
+beautiful_soup_parser
+  Specifies the HTML parser to be used by `BeautifulSoup`_.
+  Values such as ``html5lib``, ``lxml`` can be used but require those parser
+  to be installed in your project. Defaults to ``html.parser``.
+
+.. _BeautifulSoup: https://www.crummy.com/software/BeautifulSoup/
 
 Options may be specified as kwargs to the ``markdownify`` function, or as a
 nested ``Options`` class in ``MarkdownConverter`` subclasses.

--- a/README.rst
+++ b/README.rst
@@ -158,9 +158,9 @@ strip_document
   Defaults to ``STRIP``.
 
 beautiful_soup_parser
-  Specifies the HTML parser to be used by `BeautifulSoup`_.
-  Values such as ``html5lib``, ``lxml`` can be used but require those parser
-  to be installed in your project. Defaults to ``html.parser``.
+  Specify the Beautiful Soup parser to be used for interpreting HTML markup. Parsers such
+  as `html5lib`, `lxml` or even a custom parser as long as it is installed on the execution
+  environment. Defaults to ``html.parser``.
 
 .. _BeautifulSoup: https://www.crummy.com/software/BeautifulSoup/
 

--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,10 @@ heading_style
   ``SETEXT``). Defaults to ``UNDERLINED``.
 
 beautiful_soup_parser
-  Specifies the HTML parser to be used by [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/).
-  Values such as ``html5lib``, ``lxml`` can be used but require those parser to be installed in your project.
-  Defaults to ``html.parser``.
+  Specifies the HTML parser to be used by
+  [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/).
+  Values such as ``html5lib``, ``lxml`` can be used but require those parser
+  to be installed in your project. Defaults to ``html.parser``.
 
 bullets
   An iterable (string, list, or tuple) of bullet styles to be used. If the

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,11 @@ heading_style
   ``ATX_CLOSED``, ``SETEXT``, and ``UNDERLINED`` (which is an alias for
   ``SETEXT``). Defaults to ``UNDERLINED``.
 
+beautiful_soup_parser
+  Specifies the HTML parser to be used by [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/).
+  Values such as ``html5lib``, ``lxml`` can be used but require those parser to be installed in your project.
+  Defaults to ``html.parser``.
+
 bullets
   An iterable (string, list, or tuple) of bullet styles to be used. If the
   iterable only contains one item, it will be used regardless of how deeply

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -154,6 +154,7 @@ def _next_block_content_sibling(el):
 class MarkdownConverter(object):
     class DefaultOptions:
         autolinks = True
+        beautiful_soup_parser = 'html.parser'
         bullets = '*+-'  # An iterable of bullet types.
         code_language = ''
         code_language_callback = None
@@ -191,7 +192,7 @@ class MarkdownConverter(object):
         self.convert_fn_cache = {}
 
     def convert(self, html):
-        soup = BeautifulSoup(html, 'html.parser')
+        soup = BeautifulSoup(html, self.options['beautiful_soup_parser'])
         return self.convert_soup(soup)
 
     def convert_soup(self, soup):

--- a/markdownify/main.py
+++ b/markdownify/main.py
@@ -55,7 +55,9 @@ def main(argv=sys.argv[1:]):
     parser.add_argument('--no-escape-underscores', dest='escape_underscores',
                         action='store_false',
                         help="Do not escape '_' to '\\_' in text.")
-    parser.add_argument('-i', '--keep-inline-images-in', nargs='*',
+    parser.add_argument('-i', '--keep-inline-images-in',
+                        default=[],
+                        nargs='*',
                         help="Images are converted to their alt-text when the images are "
                         "located inside headlines or table cells. If some inline images "
                         "should be converted to markdown images instead, this option can "
@@ -68,6 +70,12 @@ def main(argv=sys.argv[1:]):
     parser.add_argument('-w', '--wrap', action='store_true',
                         help="Wrap all text paragraphs at --wrap-width characters.")
     parser.add_argument('--wrap-width', type=int, default=80)
+    parser.add_argument('-p', '--beautiful-soup-parser',
+                        dest='beautiful_soup_parser',
+                        default='html.parser',
+                        help="Specify the Beautiful Soup parser to be used for interpreting HTML markup. Parsers such "
+                             "as html5lib, lxml or even a custom parser as long as it is installed on the execution "
+                             "environment.")
 
     args = parser.parse_args(argv)
     print(markdownify(**vars(args)))


### PR DESCRIPTION
Hi :wave: 

As per my issue #205 and #58, I propose the following changes to allow users to choose which parser they want to use with BeautifulSoup :innocent: 

As a quick refresher, at the moment, only `html.parser` is available as the default HTML parser when using the `markdownify(..)` method. It's still possible to use the `MarkdownConverter(options).convert_soup(..)` method but having both solution si more convenient IMHO.

I haven't written any specific test for other kinds of HTML parsers as I didn't want to add extra dependencies to this project. If required I could add development dependencies only to run those specific tests.

Thanks @AlexVonB for your help with this subject :pray: 