### PR TITLE
Ensure that explicitly provided heading conversion functions are used (#212)

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -363,16 +363,20 @@ class MarkdownConverter(object):
         if not self.should_convert_tag(tag_name):
             return None
 
-        # Handle headings with convert_hN() function
+        # Look for an explicitly defined conversion function by tag name first
+        convert_fn_name = "convert_%s" % re_make_convert_fn_name.sub("_", tag_name)
+        convert_fn = getattr(self, convert_fn_name, None)
+        if convert_fn:
+            return convert_fn
+
+        # If tag is any heading, handle with convert_hN() function
         match = re_html_heading.match(tag_name)
         if match:
-            n = int(match.group(1))
+            n = int(match.group(1))  # get value of N from <hN>
             return lambda el, text, parent_tags: self.convert_hN(n, el, text, parent_tags)
 
-        # For other tags, look up their conversion function by tag name
-        convert_fn_name = "convert_%s" % re_make_convert_fn_name.sub('_', tag_name)
-        convert_fn = getattr(self, convert_fn_name, None)
-        return convert_fn
+        # No conversion function was found
+        return None
 
     def should_convert_tag(self, tag):
         """Given a tag name, return whether to convert based on strip/convert options."""

--- a/tests/test_custom_converter.py
+++ b/tests/test_custom_converter.py
@@ -14,8 +14,12 @@ class UnitTestConverter(MarkdownConverter):
         """Ensure conversion function is found for tags with special characters in name"""
         return "convert_custom_tag(): %s" % text
 
+    def convert_h1(self, el, text, parent_tags):
+        """Ensure explicit heading conversion function is used"""
+        return "convert_h1: %s" % (text)
+
     def convert_hN(self, n, el, text, parent_tags):
-        """Ensure conversion function is found for headings"""
+        """Ensure general heading conversion function is used"""
         return "convert_hN(%d): %s" % (n, text)
 
 
@@ -28,6 +32,8 @@ def test_custom_conversion_functions():
     assert md('<img src="/path/to/img.jpg" alt="Alt text" />text') == '![Alt text](/path/to/img.jpg)\n\ntext'
 
     assert md("<custom-tag>text</custom-tag>") == "convert_custom_tag(): text"
+
+    assert md("<h1>text</h1>") == "convert_h1: text"
 
     assert md("<h3>text</h3>") == "convert_hN(3): text"
 


### PR DESCRIPTION
Fixes #212.

The precedence of conversion function lookup is modified so that explicitly defined heading conversion functions (such as `convert_h3()`) take precedence over general heading conversion functions (processed by `convert_hN()`).

Unit tests are added for both cases.