### PR TITLE
Add conversion support for <q> tags

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -650,6 +650,9 @@ class MarkdownConverter(object):
 
         return '\n\n```%s\n%s\n```\n\n' % (code_language, text)
 
+    def convert_q(self, el, text, parent_tags):
+        return '"' + text + '"'
+        
     def convert_script(self, el, text, parent_tags):
         return ''
 

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -652,7 +652,7 @@ class MarkdownConverter(object):
 
     def convert_q(self, el, text, parent_tags):
         return '"' + text + '"'
-        
+
     def convert_script(self, el, text, parent_tags):
         return ''
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -305,6 +305,11 @@ def test_pre():
     assert md("<p>foo</p>\n<pre>bar</pre>\n</p>baz</p>", sub_symbol="^") == "\n\nfoo\n\n```\nbar\n```\n\nbaz"
 
 
+def test_q():
+    assert md('foo <q>quote</q> bar') == 'foo "quote" bar'
+    assert md('foo <q cite="https://example.com">quote</q> bar') == 'foo "quote" bar'
+
+
 def test_script():
     assert md('foo <script>var foo=42;</script> bar') == 'foo  bar'
 


### PR DESCRIPTION
From this issue: https://github.com/matthewwithanm/python-markdownify/issues/216

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/q

HTML that looks like this:

```html
Here is <q>A Quote</q> from someone.
```

should be rendered as:

```
Here is “A Quote“ from someone.
```

Technically, the quotes rendered from `<q>` are dependent on the browser lang attribute 

https://developer.mozilla.org/en-US/docs/Web/CSS/quotes#specifications

```html
<ul>
  <li lang="fr">
    <q>Ceci est une citation française.</q>
  </li>
  <li lang="de">
    <q>Dies ist ein deutsches Zitat</q>
  </li>
  <li lang="en">
    <q>This is an English quote.</q>
  </li>
</ul>
```

```
- «Ceci est une citation française.»
- „Dies ist ein deutsches Zitat“
- “This is an English quote.”
```

But this PR uses simple straight quotes
