### PR TITLE
Fix Beautiful Soup documentation link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,9 +170,10 @@ bs4_options
   selection. Dictionary values (such as ``{"from_encoding": "iso-8859-8"}``)
   are treated as full kwargs to be used for the BeautifulSoup constructor,
   allowing specification of any parameter. For parameter details, see the
-  Beautiful Soup documentation at:
+  `Beautiful Soup documentation`_.
 
-.. _BeautifulSoup: https://www.crummy.com/software/BeautifulSoup/bs4/doc/
+.. _Beautiful Soup documentation:
+   https://www.crummy.com/software/BeautifulSoup/bs4/doc/
 
 Options may be specified as kwargs to the ``markdownify`` function, or as a
 nested ``Options`` class in ``MarkdownConverter`` subclasses.


### PR DESCRIPTION
Currently, the link reference is defined but never used, so the link isn't displayed anywhere.

(I find it a bit ironic that the README for this library is in reStructuredText rather than Markdown.)