### PR TITLE
Add inline_br option for linebreaks in inline elements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,12 @@ newline_style
   newline). While the latter convention is non-standard, it is commonly
   preferred and supported by a lot of interpreters.
 
+inline_br
+  By default, linebreaks with ``<br>`` inside inline elements (especially table
+  cells) are replaced by spaces. This can be confusing in some contexts.
+  Setting this option replaces it by plain ``<br>`` tags, allowing actual line
+  breaks in Markdown renderers that support it.
+
 code_language
   Defines the language that should be assumed for all ``<pre>`` sections.
   Useful, if all code on a page is in the same programming language and

--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -186,6 +186,7 @@ class MarkdownConverter(object):
         escape_underscores = True
         escape_misc = False
         heading_style = UNDERLINED
+        inline_br = False
         keep_inline_images_in = []
         newline_style = SPACES
         strip = None
@@ -475,7 +476,12 @@ class MarkdownConverter(object):
 
     def convert_br(self, el, text, parent_tags):
         if '_inline' in parent_tags:
-            return ' '
+            # Some Markdown renderers allow <br> tags for line breaks inside inline elements.
+            # We can choose to keep them with inline_br.
+            if self.options['inline_br']:
+                return '<br>'
+            else:
+                return ' '
 
         if self.options['newline_style'].lower() == BACKSLASH:
             return '\\\n'

--- a/markdownify/main.py
+++ b/markdownify/main.py
@@ -46,6 +46,9 @@ def main(argv=sys.argv[1:]):
                         choices=(SPACES, BACKSLASH),
                         help="Defines the style of <br> conversions: two spaces "
                         "or backslash at the and of the line thet should break.")
+    parser.add_argument('--inline-br', action='store_true',
+                        help="A boolean indicating whether <br> tags should be preserved "
+                        "inside inline elements. If false, spaces will be used instead.")
     parser.add_argument('--code-language', default='',
                         help="Defines the language that should be assumed for all "
                         "'<pre>' sections.")


### PR DESCRIPTION
Some HTML tables (and generally, other inline elements) may use `<br>` in table cells. For example:

```html
<table>
<tr>
	<th>User</th>
	<th>Email</th>
</tr>
<tr>
	<td>John Doe</td>
	<td>john.doe@example.com</td>
</tr>
<tr>
	<td>Jane Doe</td>
	<td>jane.doe@example.com<br>jane.doe@example.org</td>
</tr>
</table>
```

Currently, line breaks with `<br>` in inline elements are replaced by spaces. The table above is converted to this by markdownify:

```
| User | Email |
| --- | --- |
| John Doe | john.doe@example.com |
| Jane Doe | jane.doe@example.com jane.doe@example.org |
```

This is acceptable, but it may lead to confusion in some cases.  
There is no official Markdown way to have line-breaks inside cells, but the de-facto standard is to use `<br>` to manage this:

```
| User | Email |
| --- | --- |
| John Doe | john.doe@example.com |
| Jane Doe | jane.doe@example.com<br>jane.doe@example.org |
```

(Note that this also works in GitHub's Markdown)

This pull request adds a `inline_br` / `--inline-br` option to keep all inline `<br>` tags. (This option is disabled by default to not disrupt existing behaviors)

All tests are passing. If I force `inline_br` on all tests, 2 are failing (because of a `<br>` conversion, which is expected). Feel free to suggest how this could be integrated in tests!