### PR TITLE
Honor the value attribute on <li> in ordered lists

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -638,7 +638,17 @@ class MarkdownConverter(object):
                 start = int(parent.get("start"))
             else:
                 start = 1
-            bullet = '%s.' % (start + len(el.find_previous_siblings('li')))
+            # An explicit `value` on an <li> sets that item's ordinal and the
+            # following items continue counting from it (per the HTML spec).
+            # Walk from this item backwards (nearest first) for the closest
+            # numeric `value`; the offset is how many items follow it.
+            number = start + len(el.find_previous_siblings('li'))
+            for offset, li in enumerate([el] + el.find_previous_siblings('li')):
+                value = li.get("value")
+                if value and str(value).isnumeric():
+                    number = int(value) + offset
+                    break
+            bullet = '%s.' % number
         else:
             depth = -1
             while el:

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -49,6 +49,13 @@ def test_ol():
     assert md('<ol start="foo"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
     assert md('<ol start="1.5"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
     assert md('<ol start="1234"><li><p>first para</p><p>second para</p></li><li><p>third para</p><p>fourth para</p></li></ol>') == '\n\n1234. first para\n\n      second para\n1235. third para\n\n      fourth para\n'
+    # An explicit `value` sets the item's ordinal; following items continue from it.
+    assert md('<ol><li>a</li><li value="5">b</li><li>c</li></ol>') == '\n\n1. a\n5. b\n6. c\n'
+    assert md('<ol><li value="7">a</li><li>b</li></ol>') == '\n\n7. a\n8. b\n'
+    assert md('<ol start="2"><li>a</li><li value="10">b</li><li value="4">c</li><li>d</li></ol>') == '\n\n2. a\n10. b\n4. c\n5. d\n'
+    # Non-numeric or negative `value` falls back to positional numbering.
+    assert md('<ol><li value="foo">a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
+    assert md('<ol><li value="-1">a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
 
 
 def test_nested_ols():


### PR DESCRIPTION
## Summary

`markdownify` numbers `<ol>` items purely by position, so an explicit `value` attribute on an `<li>` is silently ignored and the converted Markdown renders different numbering than the source HTML:

```python
>>> from markdownify import markdownify as md
>>> md('<ol><li>a</li><li value="5">b</li><li>c</li></ol>')
'\n\n1. a\n2. b\n3. c\n'    # expected '1. a', '5. b', '6. c'
```

Per the [HTML spec](https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element), `value` sets that item's ordinal and the following items continue counting from it. The library already honors `<ol start>`, but never read `<li value>`.

## Fix

In `convert_li`, before falling back to the positional number, walk from the current item backwards (nearest first, including the item itself) for the closest numeric `value`; the ordinal is `int(value) + offset`, where `offset` is the number of items between it and the current one. Non-numeric or negative `value` falls back to positional numbering, mirroring the existing `start` guard (`.isnumeric()`).

```python
number = start + len(el.find_previous_siblings('li'))
for offset, li in enumerate([el] + el.find_previous_siblings('li')):
    value = li.get("value")
    if value and str(value).isnumeric():
        number = int(value) + offset
        break
bullet = '%s.' % number
```

This composes correctly with `<ol start>` and with multiple `value` attributes:

| HTML | before | after |
|------|--------|-------|
| `<ol><li>a<li value="5">b<li>c` | 1, 2, 3 | **1, 5, 6** |
| `<ol start="2"><li>a<li value="10">b<li value="4">c<li>d` | 2, 3, 4, 5 | **2, 10, 4, 5** |
| `<ol><li value="foo">a<li>b` | 1, 2 | 1, 2 (fallback) |

## Verification

- Added 5 assertions to `tests/test_lists.py::test_ol` (the bug case, value-on-first-item, the compound `start` + multiple `value` case, and non-numeric/negative fallback). They fail before the fix and pass after.
- Full suite: **83 passed**. `flake8 --ignore=E501,W503 markdownify tests` clean.

This pull request was prepared with the assistance of AI, under my direction and review.
