### PR TITLE
fix: preserve text nested inside <br> by html.parser (#244)

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -475,12 +475,12 @@ class MarkdownConverter(object):
 
     def convert_br(self, el, text, parent_tags):
         if '_inline' in parent_tags:
-            return ' '
+            return text + ' ' if text else ' '
 
         if self.options['newline_style'].lower() == BACKSLASH:
-            return '\\\n'
+            return '\\\n' + text
         else:
-            return '  \n'
+            return '  \n' + text
 
     def convert_code(self, el, text, parent_tags):
         if '_noformat' in parent_tags:

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -81,6 +81,9 @@ def test_br():
     assert md('a<br />b<br />c', newline_style=BACKSLASH) == 'a\\\nb\\\nc'
     assert md('<h1>foo<br />bar</h1>', heading_style=ATX) == '\n\n# foo bar\n\n'
     assert md('<td>foo<br />bar</td>', heading_style=ATX) == ' foo bar |'
+    # html.parser may nest text inside <br> when mixing <br> and <br />; text must not be lost
+    assert md('a<br>b<br />c') == 'a  \nb  \nc'
+    assert md('a<br>b<br />c', newline_style=BACKSLASH) == 'a\\\nb\\\nc'
 
 
 def test_code():


### PR DESCRIPTION
## Summary

Fixes #244.

Python's `html.parser` has an edge case where text following `<br />` (written with a space before the slash) is parsed as child content of the `<br>` element instead of a sibling text node, when the preceding sibling is a bare `<br>` tag.

```python
from bs4 import BeautifulSoup
soup = BeautifulSoup('Hello<br>cruel<br />world', 'html.parser')
list(soup.children)
# ['Hello', <br/>, 'cruel', <br>world</br>]   # 'world' is nested inside <br>!
```

`convert_br` received the nested text via its `text` parameter but silently discarded it, causing characters to disappear from the output:

```python
from markdownify import markdownify as md
md('Hello<br>cruel<br />world')
# Before: 'Hello  \ncruel  '   # 'world' is lost
# After:  'Hello  \ncruel  \nworld'
```

## Fix

Append `text` to the returned line-break marker in all branches of `convert_br`. When `<br>` is used correctly as a void element, `text` is always an empty string, so the change is backward-compatible. The `_inline` branch is handled similarly for consistency.

## Test

Added two assertions to `test_br` covering the mixed `<br>` / `<br />` pattern that triggers the html.parser nesting behaviour.

This pull request was prepared with the assistance of AI, under my direction and review.