### PR TITLE
Fix #249: preserve whitespace around stripped block-level elements

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -362,16 +362,28 @@ class MarkdownConverter(object):
         # remove leading whitespace at the start or just after a
         # block-level element; remove traliing whitespace at the end
         # or just before a block-level element.
-        if (should_remove_whitespace_outside(el.previous_sibling)
+        if (self._removes_adjacent_whitespace(el.previous_sibling)
                 or (should_remove_whitespace_inside(el.parent)
                     and not el.previous_sibling)):
             text = text.lstrip(' \t\r\n')
-        if (should_remove_whitespace_outside(el.next_sibling)
+        if (self._removes_adjacent_whitespace(el.next_sibling)
                 or (should_remove_whitespace_inside(el.parent)
                     and not el.next_sibling)):
             text = text.rstrip()
 
         return text
+
+    def _removes_adjacent_whitespace(self, el):
+        """Return whether a sibling element absorbs the whitespace next to it.
+
+        Block-level elements normally do, but a block-level element that is
+        stripped (or otherwise not converted) is emitted inline, so the
+        whitespace that separates it from its neighbours must be preserved
+        instead of being collapsed away (see #249).
+        """
+        if not should_remove_whitespace_outside(el):
+            return False
+        return self.should_convert_tag(el.name.lower())
 
     def get_conv_fn_cached(self, tag_name):
         """Given a tag name, return the conversion function using the cache."""

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -16,6 +16,14 @@ def test_do_not_strip():
     assert text == '[Some Text](https://github.com/matthewwithanm)'
 
 
+def test_strip_block_element_preserves_surrounding_whitespace():
+    # A stripped block-level element is rendered inline, so the whitespace
+    # separating it from its neighbours must be preserved (see #249).
+    html = '<span>Ignored <div>Still ignored</div> tag.</span>'
+    assert md(html, strip=['div']) == 'Ignored Still ignored tag.'
+    assert md(html, convert=['span']) == 'Ignored Still ignored tag.'
+
+
 def test_convert():
     text = md('<a href="https://github.com/matthewwithanm">Some Text</a>', convert=['a'])
     assert text == '[Some Text](https://github.com/matthewwithanm)'


### PR DESCRIPTION
## Summary

Fixes #249. When a block-level element such as `<div>` is stripped (via `strip=[...]`) or excluded from a `convert=[...]` whitelist, the whitespace separating it from its neighbouring text was dropped, running the words together.

```python
from markdownify import markdownify as md

md('<span>Ignored <div>Still ignored</div> tag.</span>', strip=['div'])
# before: 'IgnoredStill ignoredtag.'
# after:  'Ignored Still ignored tag.'
```

## Root cause

`process_text()` removes whitespace immediately outside a block-level sibling (`should_remove_whitespace_outside`). That is correct for a *converted* block, which emits its own `\n\n` separation. But a stripped block is emitted **inline**, so stripping the surrounding whitespace leaves no separator at all.

## Fix

Only treat a block-level sibling as a whitespace boundary when it is actually being converted. A new helper `_removes_adjacent_whitespace()` combines the existing block-level check with `should_convert_tag()`, so a stripped (inline-rendered) sibling now keeps the separating whitespace. Converted blocks are unaffected.

The reporter's own workaround (overriding `convert_div` to pad with spaces) left a trailing space; this approach avoids that because the stripped element's own leading/trailing whitespace is still normalised — only the *inter-element* separator is preserved.

## Verification

- Added `test_strip_block_element_preserves_surrounding_whitespace` covering both `strip=['div']` and `convert=['span']`. It fails on `develop` and passes with this change.
- Full suite: **84 passed** (was 83).
- `flake8 --ignore=E501,W503 markdownify tests` clean.
- Manually confirmed no change for converted blocks (`<p>a</p><p>b</p>` → `a\n\nb`) and for stripped inline elements (`strip=['b']` still keeps spaces).

---

*Disclosure: prepared with AI assistance; reviewed and verified locally against the test suite.*
