### PR TITLE
Fix STRIP_ONE trailing newline handling

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -12,7 +12,7 @@ re_all_whitespace = re.compile(r'[\t \r\n]+')
 re_newline_whitespace = re.compile(r'[\t \r\n]*[\r\n][\t \r\n]*')
 re_html_heading = re.compile(r'h(\d+)')
 re_pre_lstrip1 = re.compile(r'^ *\n')
-re_pre_rstrip1 = re.compile(r'\n *$')
+re_pre_rstrip1 = re.compile(r'\n *\Z')
 re_pre_lstrip = re.compile(r'^[ \n]*\n')
 re_pre_rstrip = re.compile(r'[ \n]*$')
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -38,6 +38,8 @@ def test_strip_pre():
     assert markdownify("<pre>  \n  \n  Hello  \n  \n  </pre>") == "```\n  Hello\n```"
     assert markdownify("<pre>  \n  \n  Hello  \n  \n  </pre>", strip_pre=STRIP) == "```\n  Hello\n```"
     assert markdownify("<pre>  \n  \n  Hello  \n  \n  </pre>", strip_pre=STRIP_ONE) == "```\n  \n  Hello  \n  \n```"
+    assert markdownify("<pre>\n\nHello\n\n</pre>", strip_pre=STRIP_ONE) == "```\n\nHello\n\n```"
+    assert markdownify("<pre>\n\nHello\n\n\n</pre>", strip_pre=STRIP_ONE) == "```\n\nHello\n\n\n```"
     assert markdownify("<pre>  \n  \n  Hello  \n  \n  </pre>", strip_pre=None) == "```\n  \n  \n  Hello  \n  \n  \n```"
 
 


### PR DESCRIPTION
## Summary

- make `strip_pre=STRIP_ONE` anchor its trailing-newline match at the true end of the input
- add regression coverage for two and three trailing bare newlines
- preserve the existing behavior for space-padded blank lines

Fixes #255.

## Verification

- `pytest tests/test_args.py -q`
- `pytest -q`
- `flake8 --ignore=E501,W503 markdownify tests`
- `restructuredtext-lint README.rst`
- `mypy .`
- `mypy --strict tests/types.py`
- `python -m build -nwsx .`
- `git diff --check`
