### PR TITLE
Reject empty bullets option with a clear error

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -210,6 +210,11 @@ class MarkdownConverter(object):
         if self.options['strip'] is not None and self.options['convert'] is not None:
             raise ValueError('You may specify either tags to strip or tags to'
                              ' convert, but not both.')
+        if len(self.options['bullets']) == 0:
+            # convert_li cycles through bullets with `bullets[depth % len(bullets)]`,
+            # so an empty bullets sequence raises an opaque ZeroDivisionError deep in
+            # list conversion. Reject it up front with a clear message instead.
+            raise ValueError('bullets must contain at least one bullet character.')
 
         # If a string or list is passed to bs4_options, assume it is a 'features' specification
         if not isinstance(self.options['bs4_options'], dict):

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -2,8 +2,24 @@
 Test whitelisting/blacklisting of specific tags.
 
 """
-from markdownify import markdownify, LSTRIP, RSTRIP, STRIP, STRIP_ONE
+import pytest
+
+from markdownify import MarkdownConverter, markdownify, LSTRIP, RSTRIP, STRIP, STRIP_ONE
 from .utils import md
+
+
+@pytest.mark.parametrize("empty_bullets", ['', [], ()])
+def test_empty_bullets_rejected(empty_bullets):
+    # An empty bullets sequence has no bullet character to cycle through. It must
+    # be rejected at construction with a clear ValueError rather than raising an
+    # opaque ZeroDivisionError later, deep in list conversion.
+    with pytest.raises(ValueError, match="bullets must contain at least one"):
+        MarkdownConverter(bullets=empty_bullets)
+
+
+def test_non_empty_bullets_still_accepted():
+    assert md('<ul><li>a</li></ul>', bullets='-') == '\n\n- a\n'
+    assert md('<ul><li>a</li></ul>', bullets=['-']) == '\n\n- a\n'
 
 
 def test_strip():


### PR DESCRIPTION
An empty `bullets` option (`''`, `[]`, or `()`) makes `convert_li` evaluate `bullets[depth % len(bullets)]`, which raises an opaque `ZeroDivisionError` deep in unordered-list conversion the first time a list is converted (construction succeeds, so the cause is hard to spot).

This validates `bullets` at construction and raises a clear `ValueError`, matching the existing strip/convert check. Non-empty bullets (str or list) are unaffected.

Added `test_empty_bullets_rejected` and `test_non_empty_bullets_still_accepted` in tests/test_args.py.