### PR TITLE
Avoid ValueError on Unicode-numeric start/colspan attributes

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -634,7 +634,8 @@ class MarkdownConverter(object):
         # determine list item bullet character to use
         parent = el.parent
         if parent is not None and parent.name == 'ol':
-            if parent.get("start") and str(parent.get("start")).isnumeric():
+            # isdecimal matches int(); isnumeric/isdigit accept chars int() rejects
+            if parent.get("start") and str(parent.get("start")).isdecimal():
                 start = int(parent.get("start"))
             else:
                 start = 1
@@ -734,13 +735,13 @@ class MarkdownConverter(object):
 
     def convert_td(self, el, text, parent_tags):
         colspan = 1
-        if 'colspan' in el.attrs and el['colspan'].isdigit():
+        if 'colspan' in el.attrs and el['colspan'].isdecimal():
             colspan = max(1, min(1000, int(el['colspan'])))
         return ' ' + text.strip().replace("\n", " ") + ' |' * colspan
 
     def convert_th(self, el, text, parent_tags):
         colspan = 1
-        if 'colspan' in el.attrs and el['colspan'].isdigit():
+        if 'colspan' in el.attrs and el['colspan'].isdecimal():
             colspan = max(1, min(1000, int(el['colspan'])))
         return ' ' + text.strip().replace("\n", " ") + ' |' * colspan
 
@@ -761,7 +762,7 @@ class MarkdownConverter(object):
         underline = ''
         full_colspan = 0
         for cell in cells:
-            if 'colspan' in cell.attrs and cell['colspan'].isdigit():
+            if 'colspan' in cell.attrs and cell['colspan'].isdecimal():
                 full_colspan += max(1, min(1000, int(cell['colspan'])))
             else:
                 full_colspan += 1

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -48,6 +48,11 @@ def test_ol():
     assert md('<ol start="-1"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
     assert md('<ol start="foo"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
     assert md('<ol start="1.5"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
+    # Unicode numerics (superscript/fraction/CJK/roman/circled) pass isnumeric() but int() rejects them; start falls back to 1
+    assert md('<ol start="²"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
+    assert md('<ol start="½"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
+    assert md('<ol start="一"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
+    assert md('<ol start="⑤"><li>a</li><li>b</li></ol>') == '\n\n1. a\n2. b\n'
     assert md('<ol start="1234"><li><p>first para</p><p>second para</p></li><li><p>third para</p><p>fourth para</p></li></ol>') == '\n\n1234. first para\n\n      second para\n1235. third para\n\n      fourth para\n'
 
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -267,6 +267,18 @@ table_with_undefined_colspan = """<table>
     </tr>
 </table>"""
 
+# superscript ² and circled ② pass str.isdigit() but int() rejects them
+table_with_unicode_colspan = """<table>
+    <tr>
+        <th colspan="²">Name</th>
+        <th>Age</th>
+    </tr>
+    <tr>
+        <td colspan="②">Jill</td>
+        <td>Smith</td>
+    </tr>
+</table>"""
+
 table_with_colspan_missing_head = """<table>
     <tr>
         <td colspan="2">Name</td>
@@ -300,6 +312,7 @@ def test_table():
     assert md(table_with_caption) == 'TEXT\n\nCaption\n\n|  |  |  |\n| --- | --- | --- |\n| Firstname | Lastname | Age |\n\n'
     assert md(table_with_colspan) == '\n\n| Name | | Age |\n| --- | --- | --- |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |\n\n'
     assert md(table_with_undefined_colspan) == '\n\n| Name | Age |\n| --- | --- |\n| Jill | Smith |\n\n'
+    assert md(table_with_unicode_colspan) == '\n\n| Name | Age |\n| --- | --- |\n| Jill | Smith |\n\n'
     assert md(table_with_colspan_missing_head) == '\n\n|  |  |  |\n| --- | --- | --- |\n| Name | | Age |\n| Jill | Smith | 50 |\n| Eve | Jackson | 94 |\n\n'
 
 


### PR DESCRIPTION
`markdownify('<ol start="²"><li>a</li></ol>')` raises `ValueError: invalid literal for int() with base 10: '²'`. The same happens for a `colspan` attribute, e.g. `<td colspan="²">` or `<td colspan="②">`.

The list-start guard uses `str.isnumeric()` and the colspan guards use `str.isdigit()`. Both return `True` for Unicode numeric characters (superscripts, fractions, CJK numerals, roman numerals, circled digits) that the following `int()` then rejects, so the whole conversion crashes on valid HTML where a browser would just fall back to the default.

`str.isdecimal()` is `True` for exactly the characters `int()` accepts (verified across the full Unicode range), so switching the guards to it removes the crash while keeping every currently-working value identical, including the existing `"foo"` / `"-1"` / `"1.5"` / `"undefined"` fallbacks.

Repro:

```python
from markdownify import markdownify as md
md('<ol start="²"><li>a</li></ol>')                       # ValueError
md('<table><tr><td colspan="②">x</td></tr></table>')       # ValueError
```

Extended `test_ol` and `test_table` with the Unicode-attribute cases.
