### PR TITLE
remove broken remnants of Python 2 compatibility

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -1,7 +1,6 @@
 from bs4 import BeautifulSoup, Comment, Doctype, NavigableString, Tag
 from textwrap import fill
 import re
-import six
 
 
 # General-purpose regex patterns
@@ -249,7 +248,7 @@ class MarkdownConverter(object):
                 # (subclasses of NavigableString, must test first)
                 return True
             elif isinstance(el, NavigableString):
-                if six.text_type(el).strip() != '':
+                if str(el).strip() != '':
                     # Non-whitespace text nodes are always processed.
                     return False
                 elif should_remove_inside and (not el.previous_sibling or not el.next_sibling):
@@ -345,7 +344,7 @@ class MarkdownConverter(object):
         if parent_tags is None:
             parent_tags = set()
 
-        text = six.text_type(el) or ''
+        text = str(el)
 
         # normalize whitespace if we're not inside a preformatted element
         if 'pre' not in parent_tags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 2.5",
-    "Programming Language :: Python :: 2.6",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -24,7 +21,6 @@ classifiers = [
 ]
 dependencies = [
     "beautifulsoup4>=4.9,<5",
-    "six>=1.15,<2"
 ]
 
 [project.urls]


### PR DESCRIPTION
by using typing, which is a _good_ thing,
this project cannot be Python2-compatible anymore;
this cleans this up

```
$ grep Union -r
markdownify/__init__.pyi:from typing import Callable, Union
markdownify/__init__.pyi:    code_language_callback: Union[Callable[[Incomplete], Union[str, None]], None] = ...,
markdownify/__init__.pyi:    convert: Union[list[str], None] = ...,
markdownify/__init__.pyi:    strip: Union[list[str], None] = ...,
markdownify/__init__.pyi:    strip_document: Union[str, None] = ...,
markdownify/__init__.pyi:    strip_pre: Union[str, None] = ...,
markdownify/__init__.pyi:    wrap_width: Union[int, None] = ...,
markdownify/__init__.pyi:        code_language_callback: Union[Callable[[Incomplete], Union[str, None]], None] = ...,
markdownify/__init__.pyi:        convert: Union[list[str], None] = ...,
markdownify/__init__.pyi:        strip: Union[list[str], None] = ...,
markdownify/__init__.pyi:        strip_document: Union[str, None] = ...,
markdownify/__init__.pyi:        strip_pre: Union[str, None] = ...,
markdownify/__init__.pyi:        wrap_width: Union[int, None] = ...,
tests/types.py:from typing import Union
tests/types.py:def callback(el: BeautifulSoup) -> Union[str, None]:
```