### PR TITLE
perf: answer the <pre> ancestor check from parent_tags

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -293,7 +293,7 @@ class MarkdownConverter(object):
         child_strings = [s for s in child_strings if s]
 
         # Collapse newlines at child element boundaries, if needed.
-        if node.name == 'pre' or node.find_parent('pre'):
+        if node.name == 'pre' or 'pre' in parent_tags:
             # Inside <pre> blocks, do not collapse newlines.
             pass
         else:


### PR DESCRIPTION
#191 propagated the parent tag context downward so ancestor questions could be answered from
`parent_tags` instead of walking the tree. One call site in `process_tag` still walks:

```python
if node.name == 'pre' or node.find_parent('pre'):
```

`parent_tags` is in scope and already holds every ancestor tag name, so the same question is a
set lookup:

```python
if node.name == 'pre' or 'pre' in parent_tags:
```

`find_parent` runs once per node and walks to the root, which makes conversion O(nodes × depth).
Flat documents never notice, nested ones do.

## Measurement

`("<div>" * 5000) + ("<b>x</b>" * 40000) + ("</div>" * 5000)`, 366 KB:

| | develop | with this change |
|---|---|---|
| nested | 23.39 s | 0.34 s |
| same content, no nesting | 0.33 s | 0.27 s |

The flat case is the floor, so the nesting accounted for all of it.

## Equivalence

`parent_tags` excludes the node itself and so does `find_parent`, so the separate
`node.name == 'pre'` test still covers that case.

Output is byte-identical on that input and on 20,000 real-world HTML emails: 0 differences.
The existing suite passes (83 tests), along with flake8 and restructuredtext-lint.
