### PR TITLE
Guard against cyclic trees in process_tag/process_element (#256)

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -225,16 +225,29 @@ class MarkdownConverter(object):
     def convert_soup(self, soup):
         return self.process_tag(soup, parent_tags=set())
 
-    def process_element(self, node, parent_tags=None):
+    def process_element(self, node, parent_tags=None, _visited=None):
         if isinstance(node, NavigableString):
             return self.process_text(node, parent_tags=parent_tags)
         else:
-            return self.process_tag(node, parent_tags=parent_tags)
+            return self.process_tag(node, parent_tags=parent_tags, _visited=_visited)
 
-    def process_tag(self, node, parent_tags=None):
+    def process_tag(self, node, parent_tags=None, _visited=None):
         # For the top-level element, initialize the parent context with an empty set.
         if parent_tags is None:
             parent_tags = set()
+
+        # Guard against cyclic trees. A well-formed BeautifulSoup tree is acyclic,
+        # but some HTML producers (e.g. certain PDF-to-HTML pipelines) can yield a
+        # graph where a descendant references an ancestor, which would otherwise
+        # send process_tag/process_element into unbounded mutual recursion and a
+        # RecursionError. Track the ids of the tags on the current descent path and
+        # stop if one repeats.
+        if _visited is None:
+            _visited = set()
+        node_id = id(node)
+        if node_id in _visited:
+            return ''
+        _visited = _visited | {node_id}
 
         # Collect child elements to process, ignoring whitespace-only text elements
         # adjacent to the inner/outer boundaries of block elements.
@@ -285,7 +298,7 @@ class MarkdownConverter(object):
 
         # Convert the children elements into a list of result strings.
         child_strings = [
-            self.process_element(el, parent_tags=parent_tags_for_children)
+            self.process_element(el, parent_tags=parent_tags_for_children, _visited=_visited)
             for el in children_to_convert
         ]
 

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -37,3 +37,27 @@ def test_code_with_tricky_content():
 def test_special_tags():
     assert md('<!DOCTYPE html>') == ''
     assert md('<![CDATA[foobar]]>') == 'foobar'
+
+
+def test_cyclic_tree_does_not_recurse():
+    """A cyclic BeautifulSoup tree (a descendant referencing an ancestor, as
+    some PDF-to-HTML pipelines can produce) must not send process_tag /
+    process_element into unbounded recursion. Regression test for #256."""
+    import sys
+    from bs4 import BeautifulSoup
+    from markdownify import MarkdownConverter
+
+    soup = BeautifulSoup('<div><p>hello</p></div>', 'html.parser')
+    div = soup.find('div')
+    p = soup.find('p')
+    # Introduce a cycle: p now contains div, which already contains p.
+    p.contents.append(div)
+
+    original_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(300)
+    try:
+        # Must complete without raising RecursionError.
+        result = MarkdownConverter().convert_soup(soup)
+    finally:
+        sys.setrecursionlimit(original_limit)
+    assert 'hello' in result


### PR DESCRIPTION
Fixes #256.

## Problem

The mutual recursion introduced in 1.2.2 between `process_tag` and `process_element` has no cycle guard. A well-formed BeautifulSoup tree is acyclic, but some HTML producers — notably PDF-to-HTML pipelines (the reporter hit this via `marker-pdf`) — can yield a graph where a descendant node references an ancestor. Converting such input recurses without bound and crashes:

```
RecursionError: maximum recursion depth exceeded
```

Because it aborts with an unhandled exception, a single malformed document takes down the whole conversion.

## Fix

Thread an optional `_visited` set of tag `id()`s through the descent. When a tag already on the current path is re-encountered, return `` to break the cycle instead of recursing into it.

- `_visited` defaults to `None`, so existing callers and any custom converters that call `process_tag` / `process_element` directly are unaffected.
- A fresh copy is passed per level (`_visited | {node_id}`), so it only detects a node repeating on the *current descent path* — a node legitimately reached via two separate sibling branches is still processed each time.

## Test

Adds `test_cyclic_tree_does_not_recurse`, which builds a cyclic tree (a `<p>` whose contents include its own ancestor `<div>`), lowers the recursion limit, and asserts conversion completes without `RecursionError`.

## Verification (local, Python 3.11)

- **RED→GREEN**: with the fix reverted the new test fails with `RecursionError`; with the fix it passes.
- `pytest tests/` — full suite passes (**84 tests**, up from 83), no regressions.
- `flake8 --ignore=E501,W503 markdownify tests` (as `tox` runs it) is clean.