### PR TITLE
Do not duplicate a non-ASCII space when wrapping

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -675,7 +675,7 @@ class MarkdownConverter(object):
                 new_lines = []
                 for line in lines:
                     line = line.lstrip(' \t\r\n')
-                    line_no_trailing = line.rstrip()
+                    line_no_trailing = line.rstrip(' \t\r\n')
                     trailing = line[len(line_no_trailing):]
                     line = fill(line,
                                 width=self.options['wrap_width'],

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -285,6 +285,7 @@ def test_p():
     assert md('<p>1234 5678 9012<br />67890</p>', wrap=True, wrap_width=10, newline_style=SPACES) == '\n\n1234 5678\n9012  \n67890\n\n'
     assert md('First<p>Second</p><p>Third</p>Fourth') == 'First\n\nSecond\n\nThird\n\nFourth'
     assert md('<p>&nbsp;x y</p>', wrap=True, wrap_width=80) == '\n\n\u00a0x y\n\n'
+    assert md('<p>x y&nbsp;<br>z</p>', wrap=True, wrap_width=80, newline_style=SPACES) == md('<p>x y&nbsp;<br>z</p>', newline_style=SPACES) == '\n\nx y\u00a0  \nz\n\n'
 
 
 def test_pre():


### PR DESCRIPTION
`convert_p`'s wrap branch captures trailing whitespace with a bare `rstrip()` and re-appends it after `fill()`:

```python
line_no_trailing = line.rstrip()
trailing = line[len(line_no_trailing):]
line = fill(line, ...)
new_lines.append(line + trailing)
```

Bare `rstrip()` removes everything `str.isspace()` accepts, but `fill()` only strips the ASCII set — so a trailing U+00A0 is left in place by `fill()` *and* appended again. One `&nbsp;` in, two out.

```
<p>a&nbsp;<br>c</p>   wrap=False -> 'a\xa0  \nc'
                      wrap=True  -> 'a\xa0\xa0  \nc'
```

**What I ran.** With a `wrap_width` too wide to wrap anything, `wrap=True` should equal `wrap=False`. 96 documents — 8 trailing characters × 3 bodies × 2 `newline_style` × with/without `<br>` — compared between the two settings, same command on `develop` and on the patch:

| | mismatches |
|---|---|
| `develop` (bc98c9e) | **18/96** |
| patched | **0/96** |

All 18 are duplications, in six characters: U+00A0, U+202F, U+2007, U+2003, U+2009, U+3000. ASCII space and the no-trailing-character case are the controls and match in both trees. `pytest` 83 passed before and after; the added assertion fails on unpatched source. `flake8 --ignore=E501,W503` clean.

**The alternative I rejected.** Wrapping `line_no_trailing` instead of `line` also gives 0/96, and it's arguably the more obvious reading. It differs once the line actually wraps: at `wrap_width=8`, `<p>aaa bbbb&nbsp;<br>c</p>` gives

- this patch: `aaa\nbbbb\xa0` — longest content line 5
- that one: `aaa bbbb\xa0` — longest content line 9, over the requested width

because it hands `fill()` a string with the U+00A0 already removed, so the width calculation doesn't see it. A no-break space occupies a column like any other, so I kept it inside the `fill()` input. Happy to switch.

**Deliberately not touched.** The `rstrip()` in `process_text` is the other half of the pair #188 converted, and #188 said the trailing side is an open question, so that one is yours to decide; this change doesn't depend on it. This also does **not** fix #175: that report goes through `chomp()`, which is untouched here.

AI assistance: found and patched with Claude Code (Claude Opus 5, `claude-opus-5`); I reviewed and ran everything above myself.
