### PR TITLE
Fix multiline Setext heading breaks and underline widths

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -272,6 +272,10 @@ class MarkdownConverter(object):
         parent_tags_for_children = set(parent_tags)
         parent_tags_for_children.add(node.name)
 
+        if (node.name in {'h1', 'h2'} and '_inline' not in parent_tags
+                and self.options['heading_style'].lower() == UNDERLINED):
+            parent_tags_for_children.add('_setext')
+
         # if this tag is a heading or table cell, add an '_inline' parent pseudo-tag
         if (
             re_html_heading.match(node.name) is not None  # headings
@@ -433,7 +437,8 @@ class MarkdownConverter(object):
 
     def underline(self, text, pad_char):
         text = (text or '').rstrip()
-        return '\n\n%s\n%s\n\n' % (text, pad_char * len(text)) if text else ''
+        width = max((len(line) for line in text.splitlines()), default=0)
+        return '\n\n%s\n%s\n\n' % (text, pad_char * width) if text else ''
 
     def convert_a(self, el, text, parent_tags):
         if '_noformat' in parent_tags:
@@ -474,6 +479,8 @@ class MarkdownConverter(object):
         return '\n' + text + '\n\n'
 
     def convert_br(self, el, text, parent_tags):
+        if '_setext' in parent_tags:
+            return '\n' + text
         if '_inline' in parent_tags:
             return text + ' ' if text else ' '
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -181,6 +181,17 @@ def test_hn_chained():
     assert md('X<h1>First</h1>') == 'X\n\nFirst\n=====\n\n'
 
 
+def test_multiline_heading_underline_width():
+    assert md('<h1>Long first line\nShort</h1>') == '\n\nLong first line\nShort\n===============\n\n'
+    assert md('<h2>Short\nLong second line</h2>') == '\n\nShort\nLong second line\n----------------\n\n'
+    assert md('<h1></h1>') == ''
+    assert md('<h1>First\nSecond</h1>', heading_style=ATX) == '\n\n# First Second\n\n'
+    assert md('<h1>Long first line<br>Short</h1>') == '\n\nLong first line\nShort\n===============\n\n'
+    assert md('<h2>Short<br />Long second line</h2>') == '\n\nShort\nLong second line\n----------------\n\n'
+    assert md('<h1>A<br>B<br />C</h1>') == '\n\nA\nB\nC\n=\n\n'
+    assert md('<td><h1>A<br>B</h1></td>') == ' A B |'
+
+
 def test_hn_nested_tag_heading_style():
     assert md('<h1>A <p>P</p> C </h1>', heading_style=ATX_CLOSED) == '\n\n# A P C #\n\n'
     assert md('<h1>A <p>P</p> C </h1>', heading_style=ATX) == '\n\n# A P C\n\n'


### PR DESCRIPTION
Preserve `<br>` line boundaries in level-1/2 Setext headings and size their underline to the longest text line instead of counting the whole multiline string. ATX headings and table-cell inline conversion keep their existing single-line behavior.

Fixes #225 for valid `<br>` markup and literal newlines. The issue’s `</br>` spelling is malformed HTML and remains subject to the selected BeautifulSoup parser’s handling.

Validation: the regression fails on the base; all 84 tests pass after the change. Flake8 and README reStructuredText lint pass. Cases cover both heading levels, longer first/last lines, mixed break markup, empty headings, ATX, and headings inside table cells.

AI disclosure: Implemented, reviewed, and tested by OpenAI Codex under the account owner’s authorization; no human code review is claimed.
