### PR TITLE
Preserve boundary line breaks around inline emphasis

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -108,10 +108,16 @@ def abstract_inline_conversion(markup_fn):
             markup_suffix = markup_prefix
         if '_noformat' in parent_tags:
             return text
+        # Keep boundary line breaks outside the emphasis delimiters. chomp()
+        # strips newlines and would also leave a backslash break inside them.
+        leading, text, trailing = re.match(
+            r'^((?:[ \t]*\\?\n)*)(.*?)((?:[ \t]*\\?\n[ \t]*)*)$',
+            text, re.DOTALL,
+        ).groups()
         prefix, suffix, text = chomp(text)
         if not text:
-            return ''
-        return '%s%s%s%s%s' % (prefix, markup_prefix, text, markup_suffix, suffix)
+            return leading + trailing
+        return '%s%s%s%s%s%s%s' % (leading, prefix, markup_prefix, text, markup_suffix, suffix, trailing)
     return implementation
 
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -181,6 +181,17 @@ def test_hn_chained():
     assert md('X<h1>First</h1>') == 'X\n\nFirst\n=====\n\n'
 
 
+def test_line_breaks_at_emphasis_boundaries():
+    assert md('<strong><u>Title<br><br></u></strong>Text') == '**Title**  \n  \nText'
+    assert md('<b>foo<br/></b>bar') == '**foo**  \nbar'
+    assert md('<b>foo<br/></b>bar', newline_style=BACKSLASH) == '**foo**\\\nbar'
+    assert md('a<em><br/>foo</em>b') == 'a  \n*foo*b'
+    assert md('a<em><br/>foo</em>b', newline_style=BACKSLASH) == 'a\\\n*foo*b'
+    assert md('a<b><br></b>b') == 'a  \nb'
+    assert md('a<b><br></b>b', newline_style=BACKSLASH) == 'a\\\nb'
+    assert md('<b><em>foo<br/></em></b>bar') == '***foo***  \nbar'
+
+
 def test_hn_nested_tag_heading_style():
     assert md('<h1>A <p>P</p> C </h1>', heading_style=ATX_CLOSED) == '\n\n# A P C #\n\n'
     assert md('<h1>A <p>P</p> C </h1>', heading_style=ATX) == '\n\n# A P C\n\n'


### PR DESCRIPTION
Preserve leading and trailing line breaks outside inline emphasis delimiters. Previously `<b>foo<br/></b>bar` lost the break, and backslash-style breaks could leave a stray backslash inside bold markup. Keep break-only tags and nested emphasis from dropping these separators as well.

Fixes #95.

Validation: the reported nested title example fails on the base and passes with this change. All 84 tests pass; Flake8 and README reStructuredText lint pass. New coverage includes leading/trailing and repeated breaks, both newline styles, nested tags, and break-only content.

AI disclosure: Implemented, reviewed, and tested by OpenAI Codex under the account owner’s authorization; no human code review is claimed.
