### PR TITLE
Preserve text spacing in anchors without destinations

### DIFF
--- a/markdownify/__init__.py
+++ b/markdownify/__init__.py
@@ -436,12 +436,12 @@ class MarkdownConverter(object):
         return '\n\n%s\n%s\n\n' % (text, pad_char * len(text)) if text else ''
 
     def convert_a(self, el, text, parent_tags):
-        if '_noformat' in parent_tags:
+        href = el.get('href')
+        if '_noformat' in parent_tags or not href:
             return text
         prefix, suffix, text = chomp(text)
         if not text:
             return ''
-        href = el.get('href')
         title = el.get('title')
         # For the replacement see #29: text nodes underscores are escaped
         if (self.options['autolinks']
@@ -453,7 +453,7 @@ class MarkdownConverter(object):
         if self.options['default_title'] and not title:
             title = href
         title_part = ' "%s"' % title.replace('"', r'\"') if title else ''
-        return '%s[%s](%s%s)%s' % (prefix, text, href, title_part, suffix) if href else text
+        return '%s[%s](%s%s)%s' % (prefix, text, href, title_part, suffix)
 
     convert_b = abstract_inline_conversion(lambda self: 2 * self.options['strong_em_symbol'])
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -31,6 +31,14 @@ def test_a_with_title():
     assert md('<a href="https://google.com">https://google.com</a>', default_title=True) == '[https://google.com](https://google.com "https://google.com")'
 
 
+def test_a_without_destination_preserves_whitespace():
+    assert md('left<a> middle </a>right') == 'left middle right'
+    assert md('left<a href=""> middle </a>right') == 'left middle right'
+    assert md('left<a name="section"> </a>right') == 'left right'
+    assert md('left<a><strong> middle </strong></a>right') == 'left **middle** right'
+    assert md('left<a></a>right') == 'leftright'
+
+
 def test_a_shortcut():
     text = md('<a href="http://google.com">http://google.com</a>')
     assert text == '<http://google.com>'


### PR DESCRIPTION
`left<a> middle </a>right` currently converts to `leftmiddleright`. An anchor without a destination is emitted as plain text, but `convert_a` first strips its boundary whitespace as if it were constructing a link label.

Return destinationless anchor content before trimming. This preserves word boundaries for missing/empty `href`, named anchors, whitespace-only content, and nested inline markup.

Validation: all 84 tests passed on Python 3.11; public API and actual CLI checks passed, including 50 nested spans. Related open PRs #262 (destination escaping) and #280 (emphasis boundary line breaks) were inspected and do not fix destinationless-anchor whitespace. Alternative BeautifulSoup parsers were not tested.

AI disclosure: this patch and its tests were prepared with OpenAI Codex and verified by executing the tests and CLI.
